### PR TITLE
docs: refresh framing, fill stubs, add Implementations page

### DIFF
--- a/docs/glossary.mdx
+++ b/docs/glossary.mdx
@@ -7,13 +7,15 @@ sidebar_position: 99
 
 ### Agent
 
-See Process
+A program that generates and executes code on behalf of a user — including, increasingly, code that calls Distributed Async Await APIs. From the perspective of the protocol, an agent is just another process. See [Process](#process).
 
 ### Async Await
 
 Async Await is a programming model based on functions and promises that allows for concurrent execution of code within a single process.
 
 ### Async Call Graph
+
+An [Async Call Graph](#call-graph) in which the edges represent asynchronous invocations — that is, the caller continues executing concurrently with the callee, and the caller awaits a promise to receive the callee's result.
 
 ### Call Graph
 
@@ -25,15 +27,19 @@ See also:
 
 ### Concurrency
 
+The property of a system in which multiple executions may take a step at the same point in time. Concurrency introduces *partial order* — non-deterministic interleaving of steps across executions. See also [Coordination](#coordination).
+
 ### Coordination
+
+The mechanism by which concurrent executions agree on a partial order of operations. In Distributed Async Await, coordination is provided by [Promises](#promise) — a caller and callee execute concurrently, and the caller awaits a promise to receive the callee's result. See also [Concurrency](#concurrency).
 
 ### Definition
 
-See also
-
-- [Execution](#execution)
+The static description of a computation — the program text. A definition becomes an [Execution](#execution) when it is invoked. See also [Execution](#execution).
 
 ### Distribution
+
+The property of a system in which executions span multiple [Processes](#process), each with its own state and its own potential for [Failure](#interruption). Distribution introduces *partial failure* — non-deterministic termination of a subset of processes. See also [Recovery](#recovery).
 
 ### Durable Executions
 
@@ -41,11 +47,11 @@ A Durable Execution is a programming abstraction with an interruption agnostic d
 
 ### Execution
 
-See also
-
-- [Definition](#definition)
+The dynamic instance of a [Definition](#definition) — the running program, with all its in-flight state. An execution has a well-defined lifecycle: *invoke* (entry) and *return* (exit). See also [Definition](#definition).
 
 ### Function
+
+A unit of computation defined by its inputs, its outputs, and its body. In Distributed Async Await, functions compose recursively — a function may call other functions, spanning a [Call Graph](#call-graph). Together with [Promises](#promise), functions are one of two universal abstractions on which the programming model is built.
 
 ### Interruption
 
@@ -53,15 +59,23 @@ The term _interruption_ refers to a voluntary (system triggered) or involuntary 
 
 ### Interruption-agnostic
 
+A property of a [Definition](#definition): the definition (program, code) does not contain interruption detection or interruption mitigation logic. The author writes ordinary, synchronous-looking code; the protocol takes responsibility for handling interruptions transparently.
+
 ### Interruption-tolerant
 
+A property of an [Execution](#execution): an execution that experiences an interruption and subsequently recovers is equivalent to some execution that does not experience an interruption. Formally, `(⟨p⟩, →(+interruption)) ≃ (⟨p⟩, →(-interruption))`. See the [Durable Function Specification](/specification/programming-model/durable-function-specification) for the formal treatment.
+
 ### Logical Process
+
+A [Process](#process) identified by its logical identity — what the system reasons *about*. One logical process is realized by one or more [Physical Processes](#physical-process) over time; when a physical process crashes, the logical process suspends, and a successor physical process resumes it.
 
 ### Messages
 
 Messages are the means by which processes communicate with each other.
 
 ### Physical Process
+
+A concrete OS-level process that runs on a specific machine for a finite lifetime. A physical process realizes a [Logical Process](#logical-process); a single logical process may be realized by a sequence of physical processes across crashes and restarts.
 
 ### Process
 
@@ -74,6 +88,12 @@ See also
 
 ### Programming Model
 
+The developer-facing surface of a system: the abstractions that authors compose to express computation. Distributed Async Await's programming model is built on [Functions](#function) and [Promises](#promise) — the same primitives as ordinary async/await, lifted to span [Distribution](#distribution).
+
 ### Promise
 
+A representation of a future value. A promise is either *pending* or *completed*; a completed promise is either *resolved* (success) or *rejected* (failure). Promises are the universal abstraction for [Coordination](#coordination) — a caller awaits a promise to receive a callee's result. In Distributed Async Await, promises are *durable*: they persist independently of the processes that reference them. See the [Durable Promise Specification](/specification/programming-model/durable-promise-specification) for the formal API and state-transition table.
+
 ### Recovery
+
+The mechanism by which a [Logical Process](#logical-process) survives the [Failure](#interruption) of a [Physical Process](#physical-process). Recovery is the response to *partial failure*, just as [Coordination](#coordination) is the response to *partial order*. See the [Recovery Protocol](/specification/execution-model/recovery-protocol) for details.

--- a/docs/implementations.mdx
+++ b/docs/implementations.mdx
@@ -1,0 +1,45 @@
+---
+id: implementations
+title: Implementations
+sidebar_label: Implementations
+sidebar_position: 4
+---
+
+:::info Reference implementations of this specification
+
+Distributed Async Await is a vendor-neutral specification. The implementations below realize the protocol — and are the easiest way to see the spec running in code.
+
+:::
+
+## Resonate
+
+[Resonate](https://resonatehq.io) is the open-source reference implementation of Distributed Async Await. It is built around an envelope protocol and a server that keeps durable promise state, with language SDKs that express the [Programming Model](/specification/programming-model) idiomatically.
+
+| Component | Repository | Notes |
+|---|---|---|
+| Server | [resonatehq/resonate](https://github.com/resonatehq/resonate) | Implements the [Durable Promise Specification](/specification/programming-model/durable-promise-specification) state machine and the [Coordination](/specification/execution-model/coordination-protocol) + [Recovery](/specification/execution-model/recovery-protocol) protocols. |
+| TypeScript SDK | [resonatehq/resonate-sdk-ts](https://github.com/resonatehq/resonate-sdk-ts) | `@resonatehq/sdk` on npm. Generator-based; zero runtime dependencies. |
+| Python SDK | [resonatehq/resonate-sdk-py](https://github.com/resonatehq/resonate-sdk-py) | `resonate-sdk` on PyPI. |
+| Rust SDK | [resonatehq/resonate-sdk-rs](https://github.com/resonatehq/resonate-sdk-rs) | `resonate` crate. |
+
+### Mapping spec pseudo-code to SDK calls
+
+The specification uses pseudo-code (`async_local`, `async_remote`, `async_r`) to describe invocations. Reference implementations expose the same semantics through their own idioms:
+
+| Spec pseudo-code | TypeScript | Python | Rust |
+|---|---|---|---|
+| `async_local f(args)` | `yield* ctx.run(f, args)` | `yield ctx.run(f, args)` | `ctx.run(f, args).await` |
+| `async_remote f(args)` | `yield* ctx.beginRpc(f, args)` | `yield ctx.beginRpc(f, args)` | `ctx.begin_rpc(f, args).await` |
+| Application root | `await resonate.run(id, fn, ...)` | `resonate.run(id, fn, ...)` | `resonate.run(id, fn, ...).await` |
+
+For the full per-language reference, see the [Resonate documentation](https://docs.resonatehq.io/develop).
+
+## Adding an implementation
+
+Distributed Async Await is open. If you build (or are building) an implementation, open a PR against [resonatehq/distributed-async-await.io](https://github.com/resonatehq/distributed-async-await.io) to add it here.
+
+The minimum bar for inclusion is:
+
+- Implements the [Durable Promise Specification](/specification/programming-model/durable-promise-specification) state-transition table
+- Implements (or is on a path to implement) the [Coordination Protocol](/specification/execution-model/coordination-protocol)
+- Open source with an OSI-approved license

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -5,24 +5,23 @@ title: Distributed Async Await
 description: Distributed Async Await
 sidebar_label: Introduction
 sidebar_position: 1
-last_update:
-  date: "03-21-2025"
 ---
 
 # Distributed Async Await
 ## Suspend Anytime, Resume Anywhere
-#### 
+####
 
-_This is an open, vendor-neutral specification of Distributed Async Await, a durable execution framework based on async await._
+_This is an open, vendor-neutral specification of Distributed Async Await: a durable execution programming model based on functions and promises._
 
-- _Based on Functions and Promises_
-- _Simple to understand_
-- _Simple to develop_
-- _Simple to operate_
+- _Standard programming model — async/await extended to span processes, machines, and time_
+- _Open ecosystem — language- and transport-agnostic, no vendor lock-in_
+- _Designed to be read and written by humans and AI alike_
 
 ## Context
 
-The purpose of this document is to formalize Distributed Async Await, an open, vendor-neutral specification of a durable execution framework.
+The purpose of this document is to formalize Distributed Async Await, an open, vendor-neutral specification of a durable execution programming model.
+
+Software is increasingly written by both human developers and AI agents. The protocol described here is designed to be a contract that either can rely on: a small, formal surface that turns the messy realities of distributed execution — partial order, partial failure, suspension, recovery — into a programming model that reads as ordinary code.
 
 Do's
 
@@ -36,9 +35,9 @@ Don'ts
 - No complex technology stacks
 - No vendor lock-in
 
-:::info Developer Experience and Simplicity
+:::info Simplicity is the contract
 
-Developer experience is often described through two lenses: the subjective lens of developer satisfaction and the objective lens of developer productivity. This specification ties developer experience to simplicity. We posit that a delightful developer experience emerges from systems that are:
+A delightful developer experience — for humans writing code, and for agents generating it — emerges from a system that is:
 
 - Simple to understand
 - Simple to develop
@@ -48,8 +47,12 @@ Developer experience is often described through two lenses: the subjective lens 
 
 ## Structure of the specification
 
-This specification consits of three prescriptive parts:
+This specification consists of three prescriptive parts:
 
 1. Specification of the [programming model](/specification/programming-model)
 2. Specification of the [execution model](/specification/execution-model)
 3. Specification of the [system model](/specification/system-model)
+
+## Reference implementations
+
+See [Implementations](/implementations) for open-source implementations of this specification.

--- a/docs/motivation.mdx
+++ b/docs/motivation.mdx
@@ -199,11 +199,11 @@ In doing so, Distributed Async Await bridges the gap between the promise of dist
 ### Conclusion
 
 Software engineering is shaped by its abstractions.
-Good abstractions preserve desired properties while offering a delightful developer experience.
+Good abstractions preserve desired properties while offering a delightful developer experience — for the humans writing code, and increasingly for the agents generating it.
 The shift from sequential to concurrent to distributed programming has exposed the need for better abstractions that don't just mask complexity but embrace and structure it.
 
 Distributed Async Await represents a new foundation.
 It captures the operational realities of cloud-native systems—distribution across space and time—while offering a programming model grounded in clarity and composability.
 By doing so, it transforms the fragmented and ad hoc into the structured and coherent.
 
-Not by hiding the cloud, but by making it programmable.
+Not by hiding the cloud, but by making it programmable — for any developer, human or AI.

--- a/docs/specification/execution-model/recovery-protocol.mdx
+++ b/docs/specification/execution-model/recovery-protocol.mdx
@@ -11,6 +11,50 @@ The **Distributed Recovery Protocol** is responsible for the detection and recov
 
 :::
 
-_This document is a work in progress.
-It is not yet complete, and it may change in the future.
-Please check back later for updates._
+:::warning Specification in progress
+
+A formal sequence-diagram treatment of the Recovery Protocol — analogous to the [Coordination Protocol](/specification/execution-model/coordination-protocol) — is in progress. This page captures the principles the protocol operationalizes; the formal protocol description will land in a future revision.
+
+:::
+
+## What recovery means
+
+Recovery is the mechanism by which a [logical execution](/specification/system-model/executions) survives the [failure](/specification/system-model/processes#failure) of a physical process. Distributed Async Await assumes a fail-stop process failure model: a process may non-deterministically terminate without warning. When that happens, the logical execution suspends and a successor physical execution can resume the work.
+
+Recovery is the second of the two foundational protocols in Distributed Async Await:
+
+- The [Coordination Protocol](/specification/execution-model/coordination-protocol) ensures coordination across **partial order** — the non-deterministic interleaving inherent to concurrent systems.
+- The Recovery Protocol ensures recovery across **partial failure** — the non-deterministic termination inherent to distributed systems.
+
+## Where the load-bearing pieces live
+
+The recovery semantics described informally elsewhere in this specification rest on three load-bearing pieces:
+
+1. **Durable Promises persist execution state.** The state required to recreate a function execution is stored externally to any single process. See the [Durable Promise Specification](/specification/programming-model/durable-promise-specification) for the API + state-transition table.
+
+2. **Function executions are interruption-tolerant.** Re-running a durable function from the beginning, with deduplication via durable promises, converges to the same result as an uninterrupted execution. See the [Durable Function Specification](/specification/programming-model/durable-function-specification) for the formal definition of interruption tolerance.
+
+3. **Tasks claim work and report liveness.** Workers claim tasks from the durable system, heartbeat to indicate progress, and surrender claims on crash. The server uses heartbeat absence to detect failure and re-deliver invocations to a successor worker.
+
+## Properties the protocol must guarantee
+
+A Recovery Protocol implementation must satisfy:
+
+- **Liveness under failure.** A logical execution's progress is bounded by the availability of *some* worker, not any specific worker. If a worker crashes, a successor worker must be able to resume.
+
+- **Safety under recovery.** A re-invoked durable function must not externalize observable side effects twice. Side-effect deduplication is provided by the durable promises representing each step.
+
+- **Bounded re-execution.** A worker that has lost the ability to make progress (lost network, paused VM) must yield its task claim within a bounded time so a successor worker can take over without indefinite waiting.
+
+## Reference implementation pointers
+
+For implementation-level recovery semantics, see:
+
+- [The concepts that power Resonate](https://docs.resonatehq.io/evaluate/why-resonate) — recovery in the context of a working durable execution engine
+- [Implementations](/implementations) — how each language SDK realizes recovery on top of this specification
+
+## See also
+
+- [Coordination Protocol](/specification/execution-model/coordination-protocol) — the sibling protocol covering partial order
+- [Message Passing Protocol](/specification/execution-model/message-passing) — the underlying transport layer
+- [Processes](/specification/system-model/processes) — the failure model assumed by recovery

--- a/docs/specification/programming-model/durable-function-specification.mdx
+++ b/docs/specification/programming-model/durable-function-specification.mdx
@@ -44,4 +44,10 @@ Interruption tolerance can be defined formally as:
 
 :::
 
-_This document is a work in progress. Please check back later for updates._
+:::warning Specification in progress
+
+The formal interruption-tolerance definition above is stable. The remainder of this document — formal treatment of step composition, durable side-effect semantics, and the relationship between durable function state and durable promise state — is in progress.
+
+For the operational shape of durable functions in working systems, see the [Durable Promise Specification](/specification/programming-model/durable-promise-specification) (the state on which durable functions execute) and [Implementations](/implementations) (how each language SDK realizes durable functions).
+
+:::

--- a/docs/specification/programming-model/index.mdx
+++ b/docs/specification/programming-model/index.mdx
@@ -105,6 +105,12 @@ This is called a Distributed Call Graph.
 A Call Graph is zoomable — that is, it can show the full set of promises and executions, or it can show just the root executions.
 Consider the following pseudo-code, where `foo()` and `bar()` are in process a, and `baz()` is in process b.
 
+:::info Spec pseudo-code, not API
+
+The notation `async_local` / `async_remote` (and `async_r` used elsewhere in this specification) is **pseudo-code chosen for the spec**. It is not the surface API of any implementation. Reference implementations expose the same semantics through their own idioms — for example, `yield* ctx.run(fn)` for local invocation and `yield* ctx.beginRpc(fn, args)` for remote invocation in the TypeScript SDK. See [Implementations](/implementations) for the mapping per language.
+
+:::
+
 process a:
 
 ```text
@@ -140,15 +146,9 @@ To show just the distributed nature of the application, we can zoom out and show
 
 When a function calls another function within the same process it is called a Local Function Invocation (LFI).
 
-{/* ![Diagram of an LFI Call Graph](/img/lfc-call-graph.svg) */}
-
 When a function calls another function in a different Application Node, it is considered a Remote Function Invocation (RFI).
 
-{/* ![Diagram of an RFI Call Graph](/img/rfc-call-graph.svg) */}
-
-A Resonate Application can make use of both LFIs and RFIs, and thus a Resoante Call Graph can span just one or many Application Nodes.
-
-{/* ![Diagram of a Resonate Call Graph spanning multiple Application Nodes](/img/complex-rfc-call-graph.svg) */}
+An Application can make use of both LFIs and RFIs, and thus a Call Graph can span just one or many Application Nodes.
 
 ## Root promises
 
@@ -160,8 +160,6 @@ In other words, this is the execution invoked by `resonate.run()`.
 
 A Call Graph root promise is the promise associated with the first execution in a Call Graph.
 This execution is also invoked by `resonate.run()`, but it is on the "edge" and is typically the entry point into the application.
-
-{/* ![Diagram of a Resonate Call Graph with labeled root promises](/img/labeled-complex-rfc-call-graph.svg) */}
 
 import DocCardList from "@theme/DocCardList";
 import { useCurrentSidebarCategory } from "@docusaurus/theme-common";

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -3,7 +3,7 @@ import type * as Preset from "@docusaurus/preset-classic";
 
 const config: Config = {
   title: "Distributed Async Await",
-  tagline: "Specification for a holistic cloud programming model.",
+  tagline: "An open specification for durable promises across processes, machines, and time.",
   favicon: "img/daa-logo.png",
 
   // Set the production url of your site here


### PR DESCRIPTION
## Summary

Iter-57 audit (`resonate/docs/board/iteration/audit-distributed-async-await-site.md`) found drift between this site and the rest of the Resonate ecosystem after the April 2026 refocus. This PR addresses the **content drift**; **#17** handles the Kapa-widget removal in parallel.

## Findings addressed

### HIGH

- **H1 — refocus framing.** Introduction acknowledges that software is increasingly written by humans **and** agents, both of which the spec is designed to serve. Spec content (programming / execution / system models) is unchanged — the protocol is genuinely audience-agnostic; only the framing prose evolves.
- **H2 — Recovery Protocol stub.** Replaced "work in progress" wording with meaningful placeholder content: principles, load-bearing pieces, properties to guarantee, pointers to reference impls. Formal sequence-diagram treatment is still a future revision.
- **H3 — Durable Function Specification stub.** Same treatment: kept the stable formal interruption-tolerance definition; replaced the bare stub line with a callout pointing to durable-promise-spec + implementations.

### MEDIUM

- **M1 — tagline.** "Specification for a holistic cloud programming model." → "An open specification for durable promises across processes, machines, and time."
- **M4 — pseudo-code clarity.** Added a callout to the programming-model index flagging `async_local` / `async_remote` / `async_r` as spec pseudo-code (not API) with a per-language mapping table.
- **M5 — glossary stubs.** Filled 13 empty stubs (Async Call Graph, Concurrency, Coordination, Definition, Distribution, Function, Interruption-agnostic, Interruption-tolerant, Logical Process, Physical Process, Programming Model, Promise, Recovery).
- **MD4 — no implementations page.** Added `/implementations.mdx` listing Resonate + per-language SDKs + the spec-pseudo-code → SDK-call mapping.

### LOW

- **L1** — Copyright 2025: auto-fixes on rebuild (`${new Date().getFullYear()}`).
- **L2** — Removed manual `last_update: 03-21-2025` override from `introduction.mdx`; git-derived date now wins.
- **L4** — "consits" → "consists"; "langauge" line rewritten; "Resoante" (×2) removed via Local-and-Remote prose cleanup.
- **L6** — Removed four `{/* ... */}` commented-out image refs in `programming-model/index.mdx`.

## Deferred to follow-up iterations

- **M2 (brand palette)** — most CSS palette refs are inside a `/* */` comment block in `static/css/custom.css`; effective live theming is neutral Docusaurus default. Adopting the IDENTITY.md trio palette is a banner + visual workstream of its own.
- **M3 (banner missing)** — asset creation; needs design pass.
- **L5 (`www` vs apex)** — cross-repo inbound link harmonization (`sdk-py` / `docs.resonatehq.io` / `resonatehq.io`); its own iteration.
- **sdk-ts → daa.io parity link** — next sdk-ts iteration.

## Files changed

| File | Δ |
|---|---|
| `docusaurus.config.ts` | tagline (M1) |
| `docs/introduction.mdx` | H1 framing + L2 last_update + L4 typos |
| `docs/motivation.mdx` | H1 conclusion threading |
| `docs/specification/programming-model/index.mdx` | M4 pseudo-code callout + L4 "Resoante" + L6 commented diagrams |
| `docs/specification/execution-model/recovery-protocol.mdx` | H2 placeholder content |
| `docs/specification/programming-model/durable-function-specification.mdx` | H3 placeholder upgrade |
| `docs/glossary.mdx` | M5 fill 13 stubs |
| `docs/implementations.mdx` | NEW — MD4 |

## Hold for merge window

Per brand-alignment-rollout pattern. Recommended order: ship #17 (Kapa removal, small + safe) first; then this PR.

## Test plan

- [ ] `npm run build` succeeds with `onBrokenLinks: "throw"` (verifies all cross-refs resolve)
- [ ] `/implementations` route renders correctly
- [ ] Glossary cross-refs (e.g., `#concurrency`, `#process`) all click through
- [ ] After deploy: `curl -s https://www.distributed-async-await.io/ \| grep -o "Copyright[^<]*"` shows 2026
- [ ] After deploy: introduction page no longer shows the manual 03-21-2025 last-updated date
- [ ] Visual check that the "Spec pseudo-code, not API" callout renders in the programming-model page

🤖 Generated with [Claude Code](https://claude.com/claude-code)