### PR TITLE
fix(mdx): light-mode tab contrast in CodeTabs

### DIFF
--- a/components/mdx/CodeTabs.tsx
+++ b/components/mdx/CodeTabs.tsx
@@ -147,8 +147,8 @@ export function CodeTabs({ children, labels, defaultValue, values, groupId }: Co
   );
 
   return (
-    <div className="my-4 border border-primary/10">
-      <div className="flex border-b border-primary/10 bg-bright-gray-50 dark:bg-surface-elevated" role="tablist">
+    <div className="my-4 border border-bright-gray-200 dark:border-primary/10">
+      <div className="flex border-b border-bright-gray-200 dark:border-primary/10 bg-bright-gray-50 dark:bg-surface-elevated" role="tablist">
         {tabKeys.map((key, i) => (
           <button
             key={key}
@@ -157,8 +157,8 @@ export function CodeTabs({ children, labels, defaultValue, values, groupId }: Co
             onClick={() => selectTab(key)}
             className={`px-4 py-2 text-sm font-mono transition-colors focus-visible:outline-2 focus-visible:outline-secondary focus-visible:outline-offset-[-2px] ${
               activeKey === key
-                ? "text-secondary border-b-2 border-secondary -mb-px"
-                : "text-muted hover:text-bright-gray-900 dark:hover:text-primary"
+                ? "text-bright-gray-900 dark:text-secondary border-b-2 border-secondary -mb-px"
+                : "text-bright-gray-500 hover:text-bright-gray-900 dark:text-muted dark:hover:text-primary"
             }`}
           >
             {tabLabels[i]}


### PR DESCRIPTION
Light-mode readability fix, ported from the sister docs repo (resonatehq/docs.resonatehq.io#214).

The active tab (`text-secondary` = bright teal `#1EE3CF`, ~1.5:1) and inactive (`text-muted` = `#94A3B8`, ~2.4:1) both fail WCAG AA on the near-white `bright-gray-50` tab bar.

- **Active** → near-black text in light mode (`text-bright-gray-900`), with the teal underline carrying the brand accent; teal text preserved in dark.
- **Inactive** → `bright-gray-500` in light, `muted` in dark.
- Tab borders gain light-mode definition (`bright-gray-200`).

Dark mode is visually unchanged. The code-block spacing bug fixed in the docs PR is **already on `main` here**, so this PR is tabs-only.

Verified with `npm run build` (0 internal broken links).

> Note: this site shares byte-identical `CodeBlock.tsx` / `CodeTabs.tsx` with the docs repo. The docs PR also introduced a mode-aware `fg-muted` token to fix ~20 other bare `text-muted` usages broken in light mode — the same debt likely exists here and could be ported as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)