### PR TITLE
Build-a-server track: the server implementers' handbook (12 chapters)

### DIFF
--- a/content/docs/server/abstract-machine.mdx
+++ b/content/docs/server/abstract-machine.mdx
@@ -1,0 +1,141 @@
+---
+title: "The abstract machine"
+pageTitle: "The abstract machine: ServerState, effects, and handlers"
+description: "How the Lean 4 spec defines the server as a deterministic state machine — ServerState, atomic effects, and pure handler functions — and why that shape is the right foundation for an implementer."
+hideTitle: true
+---
+
+# The abstract machine: ServerState, effects, and handlers
+
+The normative specification for a conformant DAA server is not a document — it is a running Lean 4 program: [`resonatehq/resonate-specification`](https://github.com/resonatehq/resonate-specification). Everything in this track is anchored on that code. This chapter explains the machine's shape so you can read the source directly and trust what it says.
+
+## The state
+
+The machine holds one value:
+
+```lean
+structure ServerState where
+  config           : ServerConfig
+  promises         : List PromiseObject
+  tasks            : List TaskObject
+  schedules        : List Schedule
+  promiseTimeouts  : List PromiseTimeout
+  taskTimeouts     : List TaskTimeout
+  scheduleTimeouts : List ScheduleTimeout
+  outbox           : List OutboxEntry
+```
+
+That's it. Every object the server knows about lives in one of those eight fields. There is no connection pool, no clock, no filesystem reference. `ServerState` is a plain inductive value; two states are equal iff their fields are equal. This makes the spec executable as a pure function and mechanically comparable against any implementation you build.
+
+`ServerConfig` carries one field today: `retryTimeout : Nat := 5000` (milliseconds). Everything else — auth, transport, indexes — is outside the machine.
+
+## The monad
+
+The machine's computation type is:
+
+```lean
+abbrev M := StateM ServerState
+```
+
+`StateM ServerState` threads a `ServerState` through every operation without any IO. A handler runs; the state may change; the handler returns a result and the new state. Nothing else can happen inside `M`. This is the source of determinism.
+
+## Effects: the only way to touch state
+
+Handlers do not reach into `ServerState` directly. They use a fixed set of named effects defined alongside the state in [`spec/01-objects/state.lean`](https://github.com/resonatehq/resonate-specification/blob/main/spec/01-objects/state.lean):
+
+| Component | Effects |
+|---|---|
+| promises | `getPromise` / `setPromise` |
+| tasks | `getTask` / `setTask` |
+| schedules | `getSchedule` / `setSchedule` / `delSchedule` |
+| timeouts | `setPromiseTimeout` / `delPromiseTimeout` |
+| | `setTaskTimeout` / `delTaskTimeout` |
+| | `setScheduleTimeout` / `delScheduleTimeout` |
+| outbox | `setMessage` |
+
+Each effect is a small `M` action — a keyed lookup, upsert, or delete on one list. They compose. A handler is a sequence of effect calls. When you implement a storage backend, you are implementing these eight families. Get them right and every handler composes on top for free.
+
+One narrow exception: the settlement scrub — removing a newly-settled promise's id from every pending promise's callbacks list — is inlined at all three settlement sites rather than factored into a named effect. Watch for it; it is not a separate call.
+
+## Handlers: pure functions from request to result
+
+Every protocol handler has the same signature:
+
+```lean
+Req → (now : Nat) → M Res
+```
+
+`now` is the only way time enters the machine. No handler calls a clock. No handler reads an environment variable. Given the same `ServerState`, the same request, and the same `now`, a handler always produces the same `Res` and the same next `ServerState`. This is the totality property: every input produces exactly one output, no exceptions, no panics, no "it depends."
+
+The `taskAcquire` handler is a clean example. It checks state, checks version, transitions the task, arms a lease timeout, and returns:
+
+```lean
+def taskAcquire (req : TaskAcquireReq) (now : Nat) : M TaskAcquireRes := do
+  match ← getTask req.id with
+  | none => return { status := 404 }
+  | some t =>
+  ...
+  let t := { t with state := .acquired, version := t.version + 1,
+                    ttl := some req.ttl, pid := some req.pid, resumes := [] }
+  setTask t
+  delTaskTimeout t.id
+  setTaskTimeout t.id 1 (now + req.ttl)
+  return { status := 200, task := some t.toRecord, ... }
+```
+
+No surprises. The version increment, the timeout arm, the status code — all visible in one screen of Lean.
+
+## Reading the repo
+
+The spec has two directories under `spec/`:
+
+```text
+spec/
+  01-objects/
+    types.lean   ← wire records, request/response types, enums
+    state.lean   ← ServerState, PromiseObject, TaskObject, effects, M
+  02-actions/
+    00-resume.lean          ← internal: enqueueResume (settlement cascade)
+    02-timeouts.lean        ← internal: promise/task/schedule timeout transitions
+    P-01-promise.get.lean   ← protocol handlers: P- prefix = promise
+    P-02-promise.create.lean
+    ...
+    T-01-task.get.lean      ← T- prefix = task
+    T-02-task.create.lean
+    ...
+    S-01-schedule.get.lean  ← S- prefix = schedule
+    ...
+```
+
+The naming convention is `{P|T|S}-{NN}-{handler.name}.lean`. When you need to verify a claim about `task.acquire`, open `T-03-task.acquire.lean`. When you need the wire shape of `TaskRecord`, open `types.lean`. The file names are the index; you do not need to grep.
+
+`00-resume.lean` and `02-timeouts.lean` are not protocol handlers — they are internal transitions the environment fires. The timeout file handles four transitions across the three timeout lists: promise expiry, task retry, task lease expiry, and schedule fire. Both import `state.lean` for effects and compose the same way protocol handlers do.
+
+Two functions in `state.lean` are declared `opaque`:
+
+```lean
+opaque nextCron : (cron : String) → (after : Nat) → Nat
+opaque expand   : (template id : String) → (timestamp : Nat) → String
+```
+
+`opaque` means the spec asserts these functions exist and satisfy their signatures, but does not define their implementation. `nextCron` (cron arithmetic) and `expand` (schedule promise-id templating) are left to the implementer. They are specified in behavior — the timeouts handler shows exactly how they are called — but not in algorithm. This is an intentional design boundary, not an oversight.
+
+## The mental model for implementers
+
+Your server will be concurrent. It will have threads, connection pools, a transaction layer, and lock contention. None of that appears in the spec, and that is the point.
+
+The spec defines the **observable sequential behavior** your server must produce. For any sequence of requests your server processes, there must exist some sequential order in which the abstract machine produces the same sequence of responses and the same final state. Your server may be concurrent, but its observable behavior must be explainable by some sequential execution of the machine.
+
+This gives you a concrete testing strategy: replay a sequence of requests through the abstract machine, capture its state after each step, run the same sequence through your server, and diff. Any divergence is a bug in your server. Exactly one of the states is wrong.
+
+<Callout type="info" title="Concurrency and isolation are formally unspecified">
+The spec says nothing about how you serialize concurrent requests, what isolation level your storage must provide, or how you handle races between a lease expiry and an in-flight heartbeat. These are real implementation problems — they just live outside the machine's boundary. See [Unspecified surface](/server/unspecified-surface) for a full accounting of what the spec deliberately leaves open.
+</Callout>
+
+The spec's silence on concurrency is not a gap you need to fill before you can use it. You can run the machine on a single thread for testing, verify your handlers match it, and then add concurrency to your production server separately. The machine is the oracle for correctness; your concurrency strategy is the oracle for performance.
+
+The next chapter covers what the machine's state actually contains — the exact fields of every record, which are visible on the wire, and which are internal. See also [testing and conformance](/server/testing-and-conformance) for how to run the machine against your implementation in practice, and [state model](/server/state-model) for the full record definitions.
+
+---
+
+*Verified against [`resonate-specification@83d64c3`](https://github.com/resonatehq/resonate-specification/tree/83d64c3).*

--- a/content/docs/server/envelope-and-transport.mdx
+++ b/content/docs/server/envelope-and-transport.mdx
@@ -1,0 +1,187 @@
+---
+title: "Envelope and transport"
+pageTitle: "The request/response envelope and transport"
+description: "The JSON envelope every handler reads and writes, the status-code vocabulary, and how the reference server binds the protocol to HTTP — separating spec requirement from reference convention."
+hideTitle: true
+---
+
+# The request/response envelope and transport
+
+Every operation your server handles — `promise.create`, `task.acquire`, `task.suspend`, all of them — arrives inside the same JSON envelope and leaves inside a matching response envelope. Get this layer right once and every handler composes on top of it cleanly. Get it wrong and the status codes become meaningless noise.
+
+## What the Lean spec defines — and what it doesn't
+
+<Callout type="caution" title="The wire encoding is not in the Lean model">
+The [Lean specification](https://github.com/resonatehq/resonate-specification) defines the abstract state machine: per-handler `Req` and `Res` types in [`spec/01-objects/types.lean`](https://github.com/resonatehq/resonate-specification/blob/main/spec/01-objects/types.lean), handler semantics in `spec/02-actions/`. It does **not** specify how those types are encoded on the wire — the concrete JSON field names, the header shape, or the protocol-version string. Those are defined by the reference server. The next two sections describe the reference server's choices and label them as such. If you deviate, your server is not wrong by the Lean model, but SDK clients that speak the reference protocol will fail against it.
+</Callout>
+
+The Lean types are still your ground truth for handler semantics. Every `status` value in every `Res` type in `types.lean` — and every transition in the `02-actions/` files — is what your handlers must implement. The wire encoding just carries those semantics to the client.
+
+## Envelope shape
+
+*The following field names and structure match the reference server's `RequestEnvelope` / `ResponseEnvelope` types in `src/types.rs`.*
+
+### Request
+
+```json
+{
+  "kind": "promise.create",
+  "head": {
+    "corrId": "abc-123",
+    "version": "2026-04-01",
+    "auth": null
+  },
+  "data": { ... }
+}
+```
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `kind` | string | Operation name. Routes to the handler. Must be non-empty. |
+| `head.corrId` | string | Client-chosen correlation ID. Echoed back unchanged in the response. Use it to match async responses. |
+| `head.version` | string | Protocol version. The only accepted value today is `"2026-04-01"`. A mismatch produces `400`. |
+| `head.auth` | string \| null | Optional bearer token. Ignored when auth is not configured. |
+| `data` | object | Handler-specific payload. Must be a JSON object (not an array or scalar). |
+
+### Response
+
+```json
+{
+  "kind": "promise.create",
+  "head": {
+    "corrId": "abc-123",
+    "status": 200,
+    "version": "2026-04-01"
+  },
+  "data": { ... }
+}
+```
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `kind` | string | Echo of `req.kind`. Always present, even on error. |
+| `head.corrId` | string | Echo of `req.head.corrId`. |
+| `head.status` | integer | Protocol status code (not HTTP status). See the table below. |
+| `head.version` | string | Always `"2026-04-01"` in the current reference server. |
+| `data` | any | On success: typed handler response object. On error: a string error message. |
+
+## HTTP transport
+
+The Lean machine models no transport at all — but the prose specification does: [the message-passing protocol](/spec/execution-model/message-passing#address-schemes) names HTTP as the required transport, which every conformant implementation must support for both send and receive (other schemes are optional). The concrete binding below — routes, headers, JSON shape — is the reference server's. The reference server exposes a single route:
+
+```
+POST /
+Content-Type: application/json
+```
+
+All operations use this one endpoint. There are no per-resource URLs, no query parameters, no path segments that carry operation semantics. The `kind` field in the envelope is the entire routing key.
+
+The HTTP response status mirrors `head.status`. A `200 OK` from the HTTP layer means the envelope parsed and the handler ran; whether the operation itself succeeded is in `head.status`. (They will agree for success, and they agree for client errors — a `400` in the head is a `400 HTTP` — but the important thing is `head.status` is always authoritative.)
+
+Other transport bindings (WebSocket, message queue, in-process channel) are not prohibited, but none are specified. The reference server implements HTTP only.
+
+<Callout type="note" title="Legacy REST endpoints are gone">
+Earlier versions of the server exposed per-resource REST routes (`/promises`, `/tasks`, `/schedules`). The reference server returns `410 Gone` on those paths. Any client still using them needs updating before it will work against a conformant server.
+</Callout>
+
+## A concrete example: promise.create
+
+`promise.create` is the simplest handler to study because it always returns `200` — there is no 404 (idempotent: a re-create returns the existing promise), no 409, and no other success code. Every branch in [`spec/02-actions/P-02-promise.create.lean`](https://github.com/resonatehq/resonate-specification/blob/main/spec/02-actions/P-02-promise.create.lean) ends with `status := 200`.
+
+**Request:**
+
+```json
+{
+  "kind": "promise.create",
+  "head": {
+    "corrId": "c7f2a0b9",
+    "version": "2026-04-01"
+  },
+  "data": {
+    "id": "payments.charge.txn-42",
+    "timeoutAt": 1800000,
+    "param": {
+      "headers": { "content-type": "application/json" },
+      "data": "{\"amount\": 100}"
+    },
+    "tags": {
+      "resonate:target": "poll://any@workers"
+    }
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "kind": "promise.create",
+  "head": {
+    "corrId": "c7f2a0b9",
+    "status": 200,
+    "version": "2026-04-01"
+  },
+  "data": {
+    "promise": {
+      "id": "payments.charge.txn-42",
+      "state": "pending",
+      "param": {
+        "headers": { "content-type": "application/json" },
+        "data": "{\"amount\": 100}"
+      },
+      "value": {},
+      "tags": { "resonate:target": "poll://any@workers" },
+      "timeoutAt": 1800000,
+      "createdAt": 1720300000000,
+      "settledAt": null
+    }
+  }
+}
+```
+
+Field-by-field notes:
+- `data.id` — Promise identifier. The same string echoed back in `promise.id`. Dot-separated segments encode the call tree; the prefix is the origin.
+- `data.timeoutAt` — Epoch milliseconds. If this timestamp is already in the past at create time, the promise is born `rejected_timedout` (or `resolved`, for timer promises with `resonate:timer: "true"`).
+- `data.param` — Arbitrary input payload: optional `headers` map and optional `data` string. The server stores and returns it verbatim.
+- `data.tags` — Key/value pairs with semantic meaning. `resonate:target` is the delivery address for the execute message the server sends to a worker. Valid schemes: `http://`, `https://`, `poll://cast@group[/id]`, `gcps://project/topic`, `bash://`. A promise without `resonate:target` has no associated task and delivers no message.
+- `promise.createdAt` — Set by the server. Do not trust the client to supply it.
+- `promise.settledAt` — `null` until the promise reaches a terminal state; then epoch milliseconds of settlement.
+
+## Status code vocabulary
+
+These codes appear in `head.status` on every response. They are protocol-level codes, not HTTP status codes, though the reference server maps them to matching HTTP statuses.
+
+| Code | Meaning | Which handlers |
+|------|---------|----------------|
+| `200` | Success. `data` is the typed response object. | All handlers on success. |
+| `300` | Immediate resume. At least one awaited promise is already settled or expired — nothing is registered, the task stays `acquired`, and the client must handle the awakenings in-band. | `task.suspend` only. |
+| `400` | Bad request. Envelope malformed, `kind` unknown or empty, `data` not an object, `version` not accepted, or field-level validation failure. | All handlers. |
+| `403` | Forbidden. Debug operations are disabled on this server. | `debug.*` handlers only. |
+| `404` | Not found. The addressed resource does not exist. | `promise.get`, `promise.settle`, `promise.register_callback`, `promise.register_listener`, `task.get`, `task.acquire`, `task.release`, `task.fulfill`, `task.suspend`, `task.fence`, `task.halt`, `task.continue`, `schedule.get`, `schedule.delete`. Not `task.create` — its existing-promise branch answers `409`/`422`, never `404`. |
+| `409` | Conflict. The operation is semantically valid but cannot proceed: wrong task state, version mismatch, or the resource already exists in an incompatible form. | `task.create`, `task.acquire`, `task.release`, `task.fulfill`, `task.suspend`, `task.fence`, `task.halt`, `task.continue`. |
+| `422` | Unprocessable. The request is structurally valid but violates a semantic constraint — for example, an awaiter promise that has no `resonate:target` tag, an awaited promise that does not exist during suspension, or a `task.create` where the promise exists but carries no target. | `promise.register_callback`, `task.create`, `task.suspend`. |
+| `500` | Internal error. Storage failure or unexpected condition. | All handlers (as a catch-all). |
+| `501` | Not implemented. | See below. |
+| `503` | Retriable storage contention (nothing committed). A reference-server extension for serialization failures under concurrent load — not in the Lean model. | Any handler, in the reference server. See [storage strategies](/server/storage-strategies). |
+
+### Notes on the surprising codes
+
+**`300` is only ever from `task.suspend`.** No other handler returns it. It signals that at least one awaited promise is already settled or expired, so the server registered nothing and skipped parking the task — the awaited work is already done and the worker still holds the claim. The Lean spec defines this path explicitly: [`spec/02-actions/T-06-task.suspend.lean`](https://github.com/resonatehq/resonate-specification/blob/main/spec/02-actions/T-06-task.suspend.lean) line 27, when any awaited promise is `!= .pending` or past its `timeoutAt`. Do not confuse this with an error. The worker should re-run as if it received a resume message. See [state model](/server/state-model) for the full task lifecycle.
+
+**`promise.create` is 200-only.** Every branch in the Lean spec returns `status := 200`. A re-create of an existing promise returns the existing record — idempotent, still 200. There is no 409 or 404 from this handler.
+
+**`501` and the search handlers.** The Lean spec marks all three search operations as unimplemented: [`P-06-promise.search.lean`](https://github.com/resonatehq/resonate-specification/blob/main/spec/02-actions/P-06-promise.search.lean), [`T-11-task.search.lean`](https://github.com/resonatehq/resonate-specification/blob/main/spec/02-actions/T-11-task.search.lean), and [`S-04-schedule.search.lean`](https://github.com/resonatehq/resonate-specification/blob/main/spec/02-actions/S-04-schedule.search.lean) each contain only `return { status := 501 }`. The reference server implements all three and returns `200` with paginated results. This is a real divergence: the Lean model says search is not part of the spec; the reference server ships it. A minimally conformant server must handle the 501 cases (so clients don't crash on unknown status codes), but search implementation is not a spec requirement. If you implement it, match the reference server's pagination shape (`cursor`-based, max 1000 per page).
+
+**`409` vs `422` — which is which.** The split is not arbitrary: `409` means "your operation is valid but the current state won't allow it" (a worker presenting a stale version is the canonical case); `422` means "you referenced something in a way the server can't satisfy" (an awaited promise that doesn't exist, an awaiter that has no target). In practice: if you see a 409 from `task.acquire`, stop — you've been outrun. If you see a 422 from `task.suspend`, the promise ID you passed doesn't exist on this server.
+
+## Cross-references
+
+The message-level delivery contract — execute and unblock message structure, address schemes, anycast vs unicast delivery semantics — is specified in [Message Passing Protocol](/spec/execution-model/message-passing). That page covers what the server sends *to* workers; this chapter covers what workers send *to* the server.
+
+For how status codes map to task and promise state transitions, see [State Model](/server/state-model).
+
+For the surface the spec deliberately leaves open (search semantics, auth, concurrent transport bindings), see [Unspecified Surface](/server/unspecified-surface).
+
+---
+
+*Verified against [resonate-specification`@83d64c3`](https://github.com/resonatehq/resonate-specification/tree/83d64c3) and reference server [`c8d7c7b`](https://github.com/resonatehq/resonate/tree/c8d7c7b).*

--- a/content/docs/server/envelope-and-transport.mdx
+++ b/content/docs/server/envelope-and-transport.mdx
@@ -162,7 +162,7 @@ These codes appear in `head.status` on every response. They are protocol-level c
 | `422` | Unprocessable. The request is structurally valid but violates a semantic constraint — for example, an awaiter promise that has no `resonate:target` tag, an awaited promise that does not exist during suspension, or a `task.create` where the promise exists but carries no target. | `promise.register_callback`, `task.create`, `task.suspend`. |
 | `500` | Internal error. Storage failure or unexpected condition. | All handlers (as a catch-all). |
 | `501` | Not implemented. | See below. |
-| `503` | Retriable storage contention (nothing committed). A reference-server extension for serialization failures under concurrent load — not in the Lean model. | Any handler, in the reference server. See [storage strategies](/server/storage-strategies). |
+| `503` | Retriable storage contention (nothing committed). Documented reference-server design intent for serialization failures — not in the Lean model, and **not yet emitted**: the current reference server surfaces these as `500`. | None today. See [storage strategies](/server/storage-strategies). |
 
 ### Notes on the surprising codes
 

--- a/content/docs/server/implementing-promises.mdx
+++ b/content/docs/server/implementing-promises.mdx
@@ -152,7 +152,7 @@ Validate in this order:
 
 If the awaited promise is pending and `timeoutAt > now`, **and** the awaiter is also pending and `timeoutAt > now`: add `req.awaiter` to the awaited promise's callbacks list (deduped via `addCallback`).
 
-If either deadline condition fails, or if the awaited promise is already settled: return the awaited promise (possibly projected) without registering the callback. The caller sees the settled state and knows it needs to resume immediately rather than wait.
+If registration is skipped, the response is still `200` with the awaited promise — but the two skip cases look different to the caller. If the awaited promise is already settled (or expired, and therefore projected settled), the caller sees the settled state and knows to resume immediately. But if the awaited is still pending and only the *awaiter's* condition failed (expired or non-pending), the caller receives a `200` carrying a **pending** awaited promise with no signal that the registration was dropped. An SDK must not treat a pending-state `200` from `promise.register_callback` as proof the callback landed.
 
 <Callout type="note" title="The callback condition is conjunctive">
 Both the awaited and the awaiter must be pending and unexpired for a registration to land. If the awaited is pending but the awaiter has already expired, the callback is silently skipped — a dead awaiter has no task to resume. This is intentional: the settlement scrub (P-03) handles the reverse direction (settling the awaited removes its id from other promises' lists), so missing this registration causes no permanent leak.

--- a/content/docs/server/implementing-promises.mdx
+++ b/content/docs/server/implementing-promises.mdx
@@ -1,0 +1,196 @@
+---
+title: "Implementing promises"
+pageTitle: "Implementing the promise handlers"
+description: "Exact semantics for the five specified promise handlers (P-01–P-05) plus the search stub (P-06), derived from the Lean 4 specification: state transitions, idempotency rules, the settlement scrub, and the link between create and task dispatch."
+hideTitle: true
+---
+
+# Implementing the promise handlers
+
+Five specified handlers plus one deliberate stub (`promise.search`) cover the entire promise surface. They share two mechanics you will apply constantly: **timeout projection** — when a pending promise's `timeoutAt ≤ now`, return a computed settled record (`resolved` for a timer promise, `rejectedTimedout` otherwise) *without writing it*; the `onPromiseTimeout` transition is what eventually writes the settlement — and **idempotency** (returning the current state instead of an error on a repeated operation). The full projection story is in [Timeouts and projection](/server/timeouts-and-projection). This chapter applies both handler by handler.
+
+All six are specified formally in [`resonatehq/resonate-specification`](https://github.com/resonatehq/resonate-specification/tree/83d64c3/spec/02-actions).
+
+---
+
+## promise.get — P-01
+
+[`P-01-promise.get.lean`](https://github.com/resonatehq/resonate-specification/blob/main/spec/02-actions/P-01-promise.get.lean)
+
+Return the promise identified by `req.id`, applying timeout projection if it is pending and expired.
+
+```text
+404           promise does not exist
+200 + promise promise exists (pending, projected, or already settled)
+```
+
+If the promise is pending and `timeoutAt ≤ now`, do **not** write anything — return a projected record with:
+
+- `state` = `resolved` for timer promises (`resonate:timer = "true"`), `rejectedTimedout` for everything else
+- `settledAt` = `timeoutAt`
+
+The actual settlement write happens in the timeout sweep, not here. Projection is a read-time computation; `promise.get` is never the trigger for a state change.
+
+---
+
+## promise.create — P-02
+
+[`P-02-promise.create.lean`](https://github.com/resonatehq/resonate-specification/blob/main/spec/02-actions/P-02-promise.create.lean)
+
+This handler is the busiest in the server. It branches on whether the promise exists, whether it is already expired, and whether it carries scheduling tags.
+
+### When the promise does not yet exist
+
+**Case A — `timeoutAt > now` (normal create):**
+
+1. Write the promise in `pending` state.
+2. If the promise is *external* — carries `resonate:target` or is a timer promise — register a promise timeout at `timeoutAt`. External promises must be swept; promises without a target or timer tag are settled by explicit protocol operations and need no sweep.
+3. If `resonate:target` is set: create a task in `pending` at `version = 0`.
+   - If `resonate:delay` is absent, or its parsed value is ≤ `now`: schedule a retry timeout at `now + retryTimeout` and enqueue an `execute` message to the target address. Work starts immediately.
+   - If `resonate:delay` is set and its value is > `now`: schedule a retry timeout at `delay` only — **do not enqueue execute yet**. The execute fires when that timeout fires. See [Outbox and delivery](/server/outbox-and-delivery).
+4. Return 200 with the new promise record.
+
+`retryTimeout` is a server configuration value; the default in the spec is 5000 ms (`ServerConfig.retryTimeout` in `state.lean`).
+
+**Case B — `timeoutAt ≤ now` (already-expired create):**
+
+The caller asked for a promise with a deadline in the past. Write it directly as settled:
+
+- `state` = `resolved` (timer) or `rejectedTimedout` (everything else)
+- `createdAt = settledAt = timeoutAt`
+
+If `resonate:target` is present, also create a task, but in `fulfilled` state — there is no work to dispatch on an already-expired promise. Return 200.
+
+### When the promise already exists
+
+Return it as-is — or projected if it is pending and expired — and return **200**.
+
+<Callout type="caution" title="There is no 409 on duplicate create">
+`promise.create` never returns 409. A repeated call with the same `id` returns 200 with the existing promise, regardless of whether the new request's parameters match. This surprises engineers coming from create-APIs that use 409 to signal "already exists." Here, idempotency is the default: callers can safely retry a create after a network failure, and the server absorbs the duplicate. Do not add a 409 path — the spec has none.
+</Callout>
+
+The [durable promise specification](/spec/programming-model/durable-promise-specification) documents an extended surface (`ikc`/`iku`/strict modes) that the reference server implements. The Lean model does not specify these modes; a conformant-to-Lean server need not implement them.
+
+---
+
+## promise.settle — P-03
+
+[`P-03-promise.settle.lean`](https://github.com/resonatehq/resonate-specification/blob/main/spec/02-actions/P-03-promise.settle.lean)
+
+Settle is a **single parameterized verb**: `state` is a parameter to the request, not a separate operation per outcome. Resolve, reject, and cancel are argument values — there are no `promise.resolve` or `promise.reject` endpoints.
+
+```text
+404           promise does not exist
+200 + promise promise settled (or already settled / projected)
+```
+
+### The write path — pending and unexpired
+
+When the promise is pending and `timeoutAt > now`:
+
+1. Snapshot the promise's current `listeners` and `callbacks` lists.
+2. Write the promise: set `state = req.state`, `value = req.value`, `settledAt = now`, and clear `callbacks` and `listeners` to empty.
+3. Remove the promise timeout (`delPromiseTimeout`). A settled promise has no deadline to sweep.
+4. If a task exists for this promise id: transition it to `fulfilled`, clear `pid`, `ttl`, and `resumes`, and remove its timeout (`delTaskTimeout`).
+5. Run the **settlement scrub** (see below).
+6. Enqueue an `unblock` message to every address in the snapshotted listeners list. See [Outbox and delivery](/server/outbox-and-delivery).
+7. Call `enqueueResume` for each id in the snapshotted callbacks list.
+
+### The settlement scrub
+
+After a promise settles, it can never wake another awaiter — but other pending promises may still have its id in their callbacks lists. The scrub removes those stale registrations:
+
+```lean
+-- From P-03-promise.settle.lean
+modify fun s =>
+  { s with promises := s.promises.map fun q =>
+      if q.state == .pending then
+        { q with callbacks := q.callbacks.filter (· != p.id) }
+      else
+        q }
+```
+
+Walk every promise in the store. For each one that is still pending, filter the settled promise's id out of its callbacks list. Non-pending promises are left alone.
+
+**Why this matters for storage design.** The scrub is a cross-record write — one settlement event triggers a deletion across an unbounded number of rows in whatever table backs promise callbacks. A naive relational schema where callbacks are stored as a JSON array on the promise row makes this an `UPDATE ... SET callbacks = ...` for every pending promise. A separate `callbacks` join table reduces this to a single `DELETE FROM callbacks WHERE awaiter_id = :settled_id`, which scales. The choice of schema here has a measurable effect on settle latency at scale. See [Storage strategies](/server/storage-strategies) for the tradeoffs.
+
+### enqueueResume
+
+`enqueueResume` (`00-resume.lean`) transitions the awaiter's task based on its current state:
+
+- **`suspended`**: move the task to `pending`, set `resumes = [awaitedId]`, schedule a retry timeout at `now + retryTimeout`, and enqueue an `execute` message to the awaiter's `resonate:target` — but only if the awaiter promise exists and its `resonate:target` tag is non-empty; an absent or empty target sends nothing (the state change still happens). The awaiter is now claimable again.
+- **`pending`, `acquired`, or `halted`**: the task is already active; append `awaitedId` to its `resumes` list (deduped). No message is sent — the task will read the updated resumes when it next interacts with the server.
+- **`fulfilled`**: no-op. The awaiter is done.
+
+Note that `enqueueResume` does not check the awaiter promise's deadline. Deadline enforcement on the awaiter happens through the task's own lifecycle — an expired awaiter's own settlement fulfills its task.
+
+### Idempotency
+
+If the promise is already settled (any non-pending state), return it with 200. If it is pending but `timeoutAt ≤ now`, apply timeout projection and return 200. In both cases no write occurs and no messages are enqueued.
+
+The reference server (`oracle.rs`, `trigger_settlement`) implements the same three phases — fulfill the task, process callbacks, notify listeners — through `trigger_fulfilled`, `trigger_callbacks`, and `trigger_listeners` respectively. This is corroboration, not the definition.
+
+---
+
+## promise.register_callback — P-04
+
+[`P-04-promise.register_callback.lean`](https://github.com/resonatehq/resonate-specification/blob/main/spec/02-actions/P-04-promise.register_callback.lean)
+
+A callback is an **awaiter promise id**. Registering one tells the server: when the awaited promise settles, run `enqueueResume` for the awaiter.
+
+```text
+404           awaited promise does not exist
+422           awaiter promise does not exist, OR awaiter lacks resonate:target
+200 + promise awaited promise (pending, projected, or settled)
+```
+
+Validate in this order:
+
+1. Look up `req.awaited`. If absent, 404.
+2. Look up `req.awaiter`. If absent, 422.
+3. Check that the awaiter promise carries `resonate:target`. If not, 422. A callback without a target address is useless — `enqueueResume` has nowhere to send the execute message, so the server rejects the registration upfront rather than silently losing the wake-up.
+
+If the awaited promise is pending and `timeoutAt > now`, **and** the awaiter is also pending and `timeoutAt > now`: add `req.awaiter` to the awaited promise's callbacks list (deduped via `addCallback`).
+
+If either deadline condition fails, or if the awaited promise is already settled: return the awaited promise (possibly projected) without registering the callback. The caller sees the settled state and knows it needs to resume immediately rather than wait.
+
+<Callout type="note" title="The callback condition is conjunctive">
+Both the awaited and the awaiter must be pending and unexpired for a registration to land. If the awaited is pending but the awaiter has already expired, the callback is silently skipped — a dead awaiter has no task to resume. This is intentional: the settlement scrub (P-03) handles the reverse direction (settling the awaited removes its id from other promises' lists), so missing this registration causes no permanent leak.
+</Callout>
+
+---
+
+## promise.register_listener — P-05
+
+[`P-05-promise.register_listener.lean`](https://github.com/resonatehq/resonate-specification/blob/main/spec/02-actions/P-05-promise.register_listener.lean)
+
+A listener is an **address** for `unblock` message delivery. Where a callback wakes a durable awaiter through the task system, a listener delivers a direct notification to any subscriber — an external process, a gateway, a polling client.
+
+```text
+404           awaited promise does not exist
+200 + promise awaited promise (pending, projected, or settled)
+```
+
+If the awaited promise is pending and `timeoutAt > now`: add `req.address` to the promise's listeners list (deduped via `addListener`). The address will receive an `unblock` message when the promise settles, either via `promise.settle` (P-03) or the timeout sweep.
+
+If the promise is already settled or expired: return the current or projected state without registering. The caller can read the settlement value directly from the response — no notification will come.
+
+There is no 422 here. Any address string is accepted; the server does not validate that the address resolves to a reachable subscriber at registration time. See [Outbox and delivery](/server/outbox-and-delivery) for delivery semantics.
+
+---
+
+## promise.search — P-06
+
+[`P-06-promise.search.lean`](https://github.com/resonatehq/resonate-specification/blob/main/spec/02-actions/P-06-promise.search.lean)
+
+```text
+501  not implemented — unspecified surface
+```
+
+The Lean spec returns 501 unconditionally. Search semantics — filter shape, pagination, index requirements, sort order — are unspecified. See [Unspecified surface](/server/unspecified-surface).
+
+The reference server implements a search endpoint with tag-based filtering and cursor pagination. That behavior is the reference server's design, not a spec requirement. If you implement search, use the reference server as a practical starting point, but do not treat its behavior as normative.
+
+---
+
+*Verified against [resonate-specification`@83d64c3`](https://github.com/resonatehq/resonate-specification/tree/83d64c3).*

--- a/content/docs/server/implementing-schedules.mdx
+++ b/content/docs/server/implementing-schedules.mdx
@@ -1,0 +1,122 @@
+---
+title: "Implementing schedules"
+pageTitle: "Implementing schedules"
+description: "How to implement the three specified schedule handlers (plus the search stub) and the onScheduleTimeout catch-up loop in a conformant DAA server."
+hideTitle: true
+---
+
+# Implementing schedules
+
+A schedule is a cron-driven promise factory. It does not execute work; it fires `promise.create` at each tick, and the promise machinery — tasks, routing, callbacks — handles everything downstream. The four CRUD handlers are straightforward; the semantics live entirely in the timeout firing side.
+
+## The schedule object
+
+A schedule carries everything needed to describe one class of recurring work:
+
+| Field | Role |
+|---|---|
+| `id` | Schedule identifier |
+| `cron` | Cron expression — syntax is **implementation-defined** |
+| `promiseId` | Template string for the created promise's id — expanded per occurrence |
+| `promiseTimeout` | Duration (ms) added to `cronTime` to compute each promise's `timeoutAt` |
+| `promiseParam` | Value passed as `param` to each created promise |
+| `promiseTags` | Tags passed to each created promise |
+| `createdAt` | When the schedule was created |
+| `nextRunAt` | Next scheduled fire time; maintained by the server |
+| `lastRunAt` | Most recent fire time; `none` until the first tick fires |
+
+## S-01 — schedule.get
+
+Lookup by id. Returns `200` with the schedule object, or `404` if none exists. No side effects. ([S-01-schedule.get.lean](https://github.com/resonatehq/resonate-specification/blob/main/spec/02-actions/S-01-schedule.get.lean))
+
+## S-02 — schedule.create
+
+`schedule.create` is fully idempotent. The spec ([S-02-schedule.create.lean](https://github.com/resonatehq/resonate-specification/blob/main/spec/02-actions/S-02-schedule.create.lean)) checks for an existing schedule first:
+
+```lean
+match ← getSchedule req.id with
+| some s =>
+    return { status := 200, schedule := some s }
+| none =>
+    let s : Schedule := { ..., nextRunAt := nextCron req.cron now, lastRunAt := none }
+    setSchedule s
+    setScheduleTimeout s.id s.nextRunAt
+    return { status := 200, schedule := some s }
+```
+
+If a schedule with the given id already exists, it is returned unchanged — no update, no merge. If it does not exist, the server constructs it with `nextRunAt := nextCron req.cron now` and immediately arms the schedule timeout.
+
+**The response is always `200`.** There is no `201 Created`. A caller that needs to distinguish a first create from a duplicate must compare the returned schedule's `createdAt` against its own record.
+
+**`nextCron` is declared `opaque` in the spec.** Its contract — "return the next fire time strictly after the given instant" — is specified; the cron format it interprets is not. Whether you support standard five-field POSIX cron, a six-field variant with seconds, or something else is your choice. Document it; clients depend on it. See [Unspecified surface](/server/unspecified-surface).
+
+## S-03 — schedule.delete
+
+Lookup by id. If not found: return `404`. If found: call `delSchedule` and `delScheduleTimeout` atomically, then return `200`. ([S-03-schedule.delete.lean](https://github.com/resonatehq/resonate-specification/blob/main/spec/02-actions/S-03-schedule.delete.lean))
+
+The timeout disarm is required. Deleting the schedule record while leaving the timeout entry alive means the handler fires against a gone schedule — a no-op in the spec, but a wasted wakeup and a source of confusion in practice. The spec removes both or neither.
+
+## S-04 — schedule.search
+
+The spec ([S-04-schedule.search.lean](https://github.com/resonatehq/resonate-specification/blob/main/spec/02-actions/S-04-schedule.search.lean)) returns `501 Not Implemented` unconditionally. Implement it the same way. Schedule search behavior is unspecified. See [Unspecified surface](/server/unspecified-surface).
+
+## The firing side: onScheduleTimeout and catchUp
+
+When a schedule's timeout fires, the handler does not fire once — it fires for every missed occurrence since the last run. The spec calls this the catch-up loop. ([02-timeouts.lean](https://github.com/resonatehq/resonate-specification/blob/main/spec/02-actions/02-timeouts.lean), lines 77–97)
+
+```lean
+partial def catchUp (now : Nat) (s : Schedule) : M Schedule := do
+  if s.nextRunAt ≤ now then
+    let cronTime := s.nextRunAt
+    let promiseId := expand s.promiseId s.id cronTime
+    let _ ← promiseCreate
+      { id := promiseId, timeoutAt := cronTime + s.promiseTimeout,
+        param := s.promiseParam, tags := s.promiseTags } cronTime
+    catchUp now { s with lastRunAt := some cronTime, nextRunAt := nextCron s.cron cronTime }
+  else
+    return s
+
+def onScheduleTimeout (id : String) (now : Nat) : M Unit := do
+  match ← getSchedule id with
+  | none   => pure ()
+  | some s =>
+      let s ← catchUp now s
+      setSchedule s
+      delScheduleTimeout s.id
+      setScheduleTimeout s.id s.nextRunAt
+```
+
+Trace through one cycle:
+
+1. `catchUp` checks `s.nextRunAt ≤ now`. If yes, this occurrence is due.
+2. `cronTime := s.nextRunAt` — the **logical** time of this occurrence, not the wall clock `now`.
+3. The promise id is computed with `expand s.promiseId s.id cronTime`. **`expand` is declared `opaque` in the spec.** The function signature is `(template id : String) → (timestamp : Nat) → String`; the template substitution syntax is not specified. See [Unspecified surface](/server/unspecified-surface).
+4. `promiseCreate` is called with `cronTime` as the `now` argument. The promise's `timeoutAt` is `cronTime + s.promiseTimeout` — anchored to when the tick *should* have fired, not when the handler ran.
+5. The function recurses with `nextRunAt := nextCron s.cron cronTime` — advancing from the just-fired tick, not from the current wall clock. Each recursive step covers exactly one occurrence.
+6. Base case: `s.nextRunAt > now`. Return the updated schedule.
+
+After `catchUp`, `onScheduleTimeout` writes the updated schedule (with new `nextRunAt` and `lastRunAt`), disarms the current timeout entry, and arms a new one at `s.nextRunAt` — the next upcoming tick.
+
+### Normative shapes
+
+**The catch-up shape is normative.** You must call `promiseCreate` once per missed occurrence, in chronological order, each using its logical `cronTime`. Skipping missed ticks, or firing only the most recent, violates the spec.
+
+**`promiseCreate` is idempotent.** If a promise with the expanded id already exists, the call returns the existing promise and does nothing. Repeated catch-up calls for an already-fired tick are safe.
+
+**Tick-anchored timeouts are a real edge case.** Each created promise gets `timeoutAt = cronTime + s.promiseTimeout`. If `promiseTimeout` is small and the server was down long enough, `cronTime + s.promiseTimeout` may already be in the past. The `promise.create` handler creates an already-expired promise in the settled state rather than pending. Test this path explicitly — an expired-at-creation promise does not dispatch a task.
+
+<Callout type="caution" title="Catch-up fires one promise per missed tick in a tight loop">
+If a server restarts after a long outage, `catchUp` fires `promiseCreate` for every missed occurrence before returning control. A schedule that ticks every minute with a server down for an hour means sixty synchronous promise creates in one timeout handler invocation. Account for this in your storage layer and test it explicitly.
+</Callout>
+
+## Cross-references
+
+- [Timeouts and projection](/server/timeouts-and-projection) — the three timeout lists and when `onScheduleTimeout` is dispatched
+- [Implementing promises](/server/implementing-promises) — `promiseCreate` semantics that `catchUp` relies on, including the already-expired creation path
+- [Outbox and delivery](/server/outbox-and-delivery) — promises created by catch-up dispatch tasks and send execute messages if they carry a `resonate:target` tag
+- [State model](/server/state-model) — `Schedule` and `ScheduleTimeout` struct definitions
+- [Unspecified surface](/server/unspecified-surface) — `nextCron` (cron syntax) and `expand` (promise-id template syntax) are both implementation-defined
+
+---
+
+*Verified against [resonate-specification`@83d64c3`](https://github.com/resonatehq/resonate-specification/tree/83d64c3).*

--- a/content/docs/server/implementing-tasks.mdx
+++ b/content/docs/server/implementing-tasks.mdx
@@ -37,7 +37,7 @@ The path branches on whether the promise already exists.
 
 **Promise absent:**
 
-If `a.timeoutAt > now`: create the promise (`state=pending`) and the task (`state=acquired`, `version=1`, `pid` and `ttl` set from the request). Arm the promise timeout at `p.timeoutAt` (`setPromiseTimeout` — unconditional here, not gated on the promise being external) and the lease timeout. Return `200` with both records. Omit the promise timeout and `onPromiseTimeout` never fires for this promise — listeners are never unblocked and suspended awaiters never wake.
+If `a.timeoutAt > now`: create the promise (`state=pending`) and the task (`state=acquired`, `version=1`, `pid` and `ttl` set from the request). Arm the promise timeout at `p.timeoutAt` (`setPromiseTimeout` — unconditional here, unlike `promise.create`, which arms it only for external promises) and the lease timeout. Return `200` with both records. If your implementation fails to arm the promise timeout, `onPromiseTimeout` never fires for this promise — listeners are never unblocked and suspended awaiters never wake.
 
 If `a.timeoutAt ≤ now`: the window has already closed. Create a pre-settled promise — `state=resolved` for a timer promise, `state=rejectedTimedout` otherwise — and a fulfilled task (`version=0`, no `pid`/`ttl`). Return `200`. The work was never live; treat this the same as finding an already-fulfilled task.
 
@@ -122,7 +122,7 @@ Standard validation: task (404), promise (409), `t.state=acquired` (409), promis
 If all awaited promises are genuinely pending, register the task's id as a callback on each, transition `state=suspended`, clear `pid`/`ttl`/`resumes`, delete the lease timeout. Return `200`.
 
 <Callout type="info" title="300 is not an error — the task stays acquired">
-A `300` from `task.suspend` means at least one awaited promise is already settled. The task was never suspended; it remains `acquired`, and the worker still holds the claim and the version. The worker must check which awaited promises are done, collect their results, and continue driving the execution. Build your worker loop to handle `300` as the fast path for awakenings that race the suspension request.
+A `300` from `task.suspend` means at least one awaited promise is already settled or past its `timeoutAt` deadline (the spec condition is `pa.state != .pending ∨ pa.timeoutAt ≤ now` — an expired-but-stored-pending promise also triggers it). The task was never suspended; it remains `acquired`, and the worker still holds the claim and the version. The worker must check which awaited promises are done, collect their results, and continue driving the execution. Build your worker loop to handle `300` as the fast path for awakenings that race the suspension request.
 </Callout>
 
 ---

--- a/content/docs/server/implementing-tasks.mdx
+++ b/content/docs/server/implementing-tasks.mdx
@@ -1,0 +1,204 @@
+---
+title: "Implementing tasks"
+pageTitle: "Implementing tasks: the full handler reference"
+description: "Spec-precise implementation notes for the nine specified task handlers — create, acquire, fence, heartbeat, suspend, fulfill, release, halt, continue — plus task.get and the unimplemented search stub."
+hideTitle: true
+---
+
+# Implementing tasks: the full handler reference
+
+This chapter walks every task handler in the spec — what it validates, what state it writes, and where the sharp edges live. Read [the task model](/spec/system-model/tasks) for the invariants your state must satisfy at all times, and [implementing promises](/server/implementing-promises) before this chapter — `task.fence` delegates directly to those handlers.
+
+The mutating handlers share a common validation spine for acquired-task operations: task exists (404), promise exists (409), task state correct (409), promise pending and unexpired (409), version matches (409). Learn the pattern once and each handler is a short diff from it.
+
+---
+
+## `task.get` (T-01)
+
+[`T-01-task.get.lean`](https://github.com/resonatehq/resonate-specification/blob/main/spec/02-actions/T-01-task.get.lean) — a read with a projection rule.
+
+If the task is not found — or the task is found but its promise is not — return `404`. If both exist and the associated promise is `pending` with `timeoutAt > now`, return the stored task record as-is (`200`). Otherwise return a synthesized record with `state=fulfilled`, `pid=null`, `ttl=null`, `resumes=[]` — also `200`.
+
+```text
+task or promise not found → 404
+promise pending + unexpired → 200 (real record)
+promise settled or expired  → 200 (projected fulfilled)
+```
+
+The projection is a read-time transformation, not a write. The stored task record is unchanged; you are presenting the logical state the client should see once a promise can no longer be fulfilled. Full projection semantics are described in [timeouts and projection](/server/timeouts-and-projection).
+
+---
+
+## `task.create` (T-02)
+
+[`T-02-task.create.lean`](https://github.com/resonatehq/resonate-specification/blob/main/spec/02-actions/T-02-task.create.lean) — atomic promise creation with immediate task acquisition.
+
+The path branches on whether the promise already exists.
+
+**Promise absent:**
+
+If `a.timeoutAt > now`: create the promise (`state=pending`) and the task (`state=acquired`, `version=1`, `pid` and `ttl` set from the request). Arm the promise timeout at `p.timeoutAt` (`setPromiseTimeout` — unconditional here, not gated on the promise being external) and the lease timeout. Return `200` with both records. Omit the promise timeout and `onPromiseTimeout` never fires for this promise — listeners are never unblocked and suspended awaiters never wake.
+
+If `a.timeoutAt ≤ now`: the window has already closed. Create a pre-settled promise — `state=resolved` for a timer promise, `state=rejectedTimedout` otherwise — and a fulfilled task (`version=0`, no `pid`/`ttl`). Return `200`. The work was never live; treat this the same as finding an already-fulfilled task.
+
+**Promise exists:**
+
+First check: the existing promise must carry the `resonate:target` tag. If it does not, return `422`.
+
+Then look up the task:
+
+| Task state | Response |
+|---|---|
+| No task found | `409` |
+| `fulfilled` | `200`, returned as-is |
+| `pending` | re-acquire: `version++`, `state=acquired`, set `pid`/`ttl`, clear `resumes`, delete retry timeout, arm lease timeout; `200` |
+| `acquired`, `suspended`, or `halted` | `409` |
+
+<Callout type="caution" title="resonate:target is only checked on existing promises">
+A fresh `task.create` whose promise does not yet exist succeeds whether or not the request carries a `resonate:target` tag — the tag check does not appear in the absent-promise branch of the spec. The check fires only when the promise already exists. Do not pre-validate tag presence on a fresh create; you will reject requests the spec accepts.
+</Callout>
+
+---
+
+## `task.acquire` (T-03)
+
+[`T-03-task.acquire.lean`](https://github.com/resonatehq/resonate-specification/blob/main/spec/02-actions/T-03-task.acquire.lean) — the standard entry point for a worker claiming a dispatched task.
+
+Validate in this order:
+
+1. Task not found → `404`.
+2. Promise not found → `409`.
+3. `t.state != .pending` → `409`.
+4. `p.state != .pending` or `p.timeoutAt ≤ now` → `409`.
+5. `t.version != req.version` → `409`.
+
+On success: `version++`, `state=acquired`, set `pid`/`ttl`, clear `resumes`, delete the retry timeout, arm the lease timeout. Return `200` with both records. Clearing `resumes` matters: a task can accumulate buffered wakeups while `pending` (awaited promises settling before re-acquire), and the acquiring worker must not see a prior cycle's phantom resumes.
+
+**Version semantics — read this carefully.**
+
+Version increments on every `pending→acquired` transition. That transition happens in two places: `task.acquire` (T-03) and the re-acquire branch of `task.create` (T-02, when the promise exists and the task is `pending`). It does not change anywhere else.
+
+<Callout type="danger" title="Version does NOT increment when a task returns to pending">
+An earlier draft of the protocol prose described this inverted — as if version incremented at the moment a task returned to `pending`. The Lean spec is unambiguous: the `version + 1` expression appears only in the `pending→acquired` branches of T-02 and T-03. `task.release` (T-08), `task.continue` (T-10), lease-expiry recovery, and the resume path (`00-resume.lean`) all return a task to `pending` at its stored version. The *next* acquire bumps it.
+
+If your implementation increments version on release or lease expiry, the execute message that re-dispatches the task will carry the wrong (pre-bump) version, and a correct worker will fail its version check on acquire.
+</Callout>
+
+---
+
+## `task.fence` (T-04)
+
+[`T-04-task.fence.lean`](https://github.com/resonatehq/resonate-specification/blob/main/spec/02-actions/T-04-task.fence.lean) — version-guarded delegation to promise handlers.
+
+Validate: task exists (404), promise exists (409), `t.state=acquired` (409), promise `pending+unexpired` (409), version match (409). On success, delegate to the **full** `promise.create` or `promise.settle` handler — the complete implementation including task dispatch and settlement chains, not a stripped copy. The outer response status is always `200` (the fence succeeded); the inner action result carries its own status, which the caller must inspect.
+
+This is how a worker makes writes safe against its own zombie predecessors. A process that lost its lease cannot pass the version check; it discovers it is dead before it acts, not after. See [implementing promises](/server/implementing-promises) for the handler semantics being delegated to.
+
+---
+
+## `task.heartbeat` (T-05)
+
+[`T-05-task.heartbeat.lean`](https://github.com/resonatehq/resonate-specification/blob/main/spec/02-actions/T-05-task.heartbeat.lean) — lease refresh for a batch of tasks.
+
+The server iterates `req.tasks`. For each entry, it checks: task exists, `state=acquired`, `version=ref.version`, `pid=req.pid`, and the associated promise is `pending+unexpired`. If all conditions hold, it deletes the existing timeout and arms a new one at `now + t.ttl`. Entries that fail any check are silently skipped.
+
+Response is always `200`. There is **no error signal for a lost task** in the heartbeat response. If another worker has re-acquired a listed task, the heartbeat simply doesn't refresh it. The original worker learns about the loss on its next mutation attempt, which returns `409`.
+
+Two corollaries for your implementation:
+
+- Do not infer from a `200` heartbeat that all listed tasks are still live.
+- The server does not look up tasks by `pid`; it only validates the tasks explicitly named in `req.tasks`. A task absent from the list — even one held by the requesting worker — will not have its lease refreshed.
+
+---
+
+## `task.suspend` (T-06)
+
+[`T-06-task.suspend.lean`](https://github.com/resonatehq/resonate-specification/blob/main/spec/02-actions/T-06-task.suspend.lean) — park on awaited promises.
+
+Standard validation: task (404), promise (409), `t.state=acquired` (409), promise `pending+unexpired` (409), version match (409). Each action in `req.actions` names an awaited promise; if any named promise does not exist, return `422`.
+
+**Before committing the suspension**, scan every awaited promise. If any is already settled or expired (`p.state != .pending` or `p.timeoutAt ≤ now`), do not suspend. Instead: clear the task's `resumes` field (reset any buffered wakeups), and return `300`. The task remains `acquired`. The worker must handle the awakenings in-band.
+
+If all awaited promises are genuinely pending, register the task's id as a callback on each, transition `state=suspended`, clear `pid`/`ttl`/`resumes`, delete the lease timeout. Return `200`.
+
+<Callout type="info" title="300 is not an error — the task stays acquired">
+A `300` from `task.suspend` means at least one awaited promise is already settled. The task was never suspended; it remains `acquired`, and the worker still holds the claim and the version. The worker must check which awaited promises are done, collect their results, and continue driving the execution. Build your worker loop to handle `300` as the fast path for awakenings that race the suspension request.
+</Callout>
+
+---
+
+## `task.fulfill` (T-07)
+
+[`T-07-task.fulfill.lean`](https://github.com/resonatehq/resonate-specification/blob/main/spec/02-actions/T-07-task.fulfill.lean) — atomic settlement of promise and task.
+
+Standard validation. On success:
+
+1. Settle the promise: write `state`, `value`, `settledAt`; clear `callbacks` and `listeners`.
+2. Delete the promise timeout.
+3. Set task to `fulfilled`: clear `pid`, `ttl`, `resumes`.
+4. Delete the task timeout.
+5. **Settlement scrub:** scan all pending promises and remove the just-fulfilled promise's id from their callback lists. A callback pointing at a now-fulfilled promise is unreachable, and leaving stale registrations would violate the invariant that no suspended task holds a dead callback.
+6. Emit an `unblock` message to every listener address.
+7. Call `enqueueResume` for every awaiter callback — waking each suspended task that was waiting on this promise.
+
+Steps 6 and 7 are the settlement propagation chain. See [outbox and delivery](/server/outbox-and-delivery) for how outbox messages reach workers.
+
+---
+
+## `task.release` (T-08)
+
+[`T-08-task.release.lean`](https://github.com/resonatehq/resonate-specification/blob/main/spec/02-actions/T-08-task.release.lean) — return a task from `acquired` to `pending`.
+
+Standard validation. On success: `state=pending`, clear `pid`/`ttl`, delete the lease timeout, arm a retry timeout. Emit an execute message to `resonate:target` carrying the task's **current version** (not incremented).
+
+The task is now claimable again. The version in the execute message is the version the next worker will present to `task.acquire`, which will then bump it. Emitting the current version is correct; do not pre-increment it here.
+
+---
+
+## `task.halt` and `task.continue` (T-09, T-10)
+
+Administrative pause and resume — not part of the normal worker loop.
+
+**`task.halt` ([T-09](https://github.com/resonatehq/resonate-specification/blob/main/spec/02-actions/T-09-task.halt.lean)):**
+
+Look up the task (404 if absent). Then:
+
+- `state=fulfilled` → `409`.
+- `state=halted` → `200` (idempotent).
+- Any other state (`pending`, `acquired`, `suspended`) → `state=halted`, clear `pid`/`ttl`, delete task timeout → `200`.
+
+There is **no version check** and no promise lookup. `task.halt` is an administrative override; it does not require the caller to be the current claimant.
+
+**`task.continue` ([T-10](https://github.com/resonatehq/resonate-specification/blob/main/spec/02-actions/T-10-task.continue.lean)):**
+
+Look up the task (404 if absent). If `state != .halted` → `409`. Look up the promise (404 if absent). On success: `state=pending`, arm a retry timeout, emit an execute message with the current version. Return `200`.
+
+A halted task holds no lease and no retry slot but retains its version. The next `task.acquire` bumps the version as usual.
+
+---
+
+## The resume path
+
+`enqueueResume` is an internal operation called for each callback on a settling promise — by `task.fulfill` (T-07), by `promise.settle` (P-03), and by the `onPromiseTimeout` transition. It is not an HTTP handler; your server calls it directly during settlement.
+
+Source: [`00-resume.lean`](https://github.com/resonatehq/resonate-specification/blob/main/spec/02-actions/00-resume.lean).
+
+| Awaiting task state | Action |
+|---|---|
+| `suspended` | `state=pending`, `resumes=[awaitedId]`, arm retry timeout, emit execute with **current version** (only if the awaiter promise exists with a non-empty `resonate:target`) |
+| `pending`, `acquired`, or `halted` | Buffer `awaitedId` in `task.resumes` (deduplicated); no state change, no execute |
+| `fulfilled` | No-op |
+
+The execute message on resume carries the pre-acquire version. This is correct: the worker that receives the execute calls `task.acquire` with that version, and `task.acquire` is what bumps it. Bumping here would put the execute message out of sync with the stored version, breaking the version check on the next acquire.
+
+The buffering behavior for `pending`/`acquired`/`halted` tasks ensures that a wakeup arriving while a task is already running (or paused) is not lost. The worker reads the accumulated `resumes` field when it next inspects its task record.
+
+---
+
+## `task.search` (T-11)
+
+[`T-11-task.search.lean`](https://github.com/resonatehq/resonate-specification/blob/main/spec/02-actions/T-11-task.search.lean) returns `501 Not Implemented`. The filtering contract is unspecified. See [unspecified surface](/server/unspecified-surface).
+
+---
+
+*Verified against [resonate-specification`@83d64c3`](https://github.com/resonatehq/resonate-specification/tree/83d64c3).*

--- a/content/docs/server/index.mdx
+++ b/content/docs/server/index.mdx
@@ -1,12 +1,147 @@
 ---
 title: "Overview"
 pageTitle: "Build a server"
-description: "How to implement a conformant Distributed Async Await server — abstract machine, state model, storage strategies, and conformance testing."
+description: "Why durable execution is a protocol, what conformance means, and how the three existing implementations prove any sufficiently capable substrate can become a provider."
 hideTitle: true
 ---
 
 # Build a server
 
-This track is coming. It will cover how to implement a conformant Distributed Async Await server.
+The Distributed Async Await protocol is specified twice, on purpose.
+[`resonatehq/resonate-specification`](https://github.com/resonatehq/resonate-specification) is the
+executable abstract machine in Lean 4 — the normative, machine-checkable definition of every handler
+and state transition. The [/spec pages](/spec) are the prose specification: the human-readable
+companion that explains the same protocol. Where prose and Lean disagree, the Lean model wins.
 
-Start with the [Specification](/spec) to understand the protocol, and [`resonatehq/resonate-specification`](https://github.com/resonatehq/resonate-specification) for the normative Lean 4 abstract machine.
+This track is for engineers implementing a conformant server — on a new substrate, in a new language,
+or as an authoritative study of what conformance actually requires.
+
+## Durable execution is a protocol, not a product
+
+Most workflow engines ship as a system you adopt: run their cluster, use their API, accept their
+operational model. The Distributed Async Await design inverts that. The protocol defines an abstract
+machine — a state, a set of atomic effects on that state, and a set of request handlers defined as
+pure functions over both. Any platform that can durably store that state and execute those effects
+atomically can become a durable-execution provider.
+
+This matters practically. Your organization may already operate a relational database, a wide-column
+store, or a message broker. If that substrate can provide durable storage and an atomic
+compare-and-swap-equivalent primitive, it can speak this protocol. You do not need to adopt new
+infrastructure — you need to implement the protocol spec against the infrastructure you already run.
+
+The honest mechanism is: **implement the protocol spec against your platform.** Not "drop in a storage
+adapter to an existing server." Three independent implementations prove the point across three radically
+different storage paradigms; none of them is a plugin to any other.
+
+## What "conformant" means
+
+A conformant server implements the protocol handlers the Lean abstract machine defines and holds the
+invariants the machine specifies after every handler invocation. That is the entire contract.
+
+Concretely:
+
+- Every handler the spec defines — `promise.get`, `promise.create`, `promise.settle`,
+  `promise.register_callback`, `promise.register_listener`, `task.acquire`, `task.create`,
+  `task.fence`, `task.heartbeat`, `task.suspend`, `task.fulfill`, `task.release`, `task.halt`,
+  `task.continue`, `schedule.get`, `schedule.create`, `schedule.delete`, plus the internal
+  `resume` and `timeouts` transitions — must behave as the corresponding Lean function specifies.
+- State transitions must be atomic with respect to the spec's state model. A handler either
+  completes all its effects or none.
+- The invariants the machine holds over promises, tasks, schedules, timeouts, and the outbox must
+  hold after every transition.
+
+What is *not* specified is as important as what is. Transport encoding, authentication, search
+handlers (`promise.search`, `task.search`, `schedule.search` are `501` stubs in the spec),
+cron-expression evaluation, and concurrency limits are intentionally left to the implementer. The spec
+does not require HTTP. It does not require JSON. It does not require any specific storage engine.
+Those decisions are yours. The handlers and their state semantics are not.
+
+<Callout type="info" title="No public conformance suite yet">
+The mechanism that verifies conformance — an oracle-diff harness that replays operation sequences and
+checks invariants after every step — exists and is used internally. It is not yet public. Treat it as
+an open question rather than a drop-in tool your CI can point at today. The
+[testing and conformance chapter](/server/testing-and-conformance) covers how to build toward that bar now.
+</Callout>
+
+## Three implementations as proof
+
+Three implementations exist today across three distinct storage paradigms. Together they demonstrate
+that substrate independence is a property the protocol already has, not an aspiration.
+
+### resonatehq/resonate — relational SQL, the reference server
+
+[`resonatehq/resonate`](https://github.com/resonatehq/resonate) is the mature reference
+implementation. Written in Rust, licensed Apache-2.0. It ships with three built-in storage backends —
+SQLite, Postgres, and MySQL — selectable at startup. Its HTTP/JSON wire protocol defines the envelope
+all existing Resonate SDKs speak.
+
+This is the implementation to study first. It is the most complete, the most tested, and the one the
+SDKs were built against. When this track says "the reference server," it means this.
+
+### resonatehq/resonate-on-scylladb — wide-column NoSQL
+
+[`resonatehq/resonate-on-scylladb`](https://github.com/resonatehq/resonate-on-scylladb) is a
+complete, independent reimplementation of the protocol in Go, backed by ScyllaDB (a
+Cassandra-compatible wide-column store). It is source-available under BUSL-1.1 (free for development
+and evaluation; commercial license for production; converts to Apache 2.0 on 2030-07-01).
+
+Its consistency mechanism is ScyllaDB Lightweight Transactions — Paxos-based compare-and-swap — which
+realizes the atomic effects the spec requires. It speaks **the same HTTP/JSON envelope as the
+reference server** (protocol version `2026-04-01`, `kind`-multiplexed POST). Any existing Resonate
+SDK points at it unchanged. It is a true drop-in backend swap.
+
+This is an official Resonate HQ project (not a community fork), actively developed. Its test rigor is
+exceptional: oracle-diff against the reference server, random-kill fault injection across 51 named
+invariants, and Porcupine linearizability verification. It is not yet at 1.0 and has known open
+issues. Label it accordingly — most credible non-reference production story, not yet production-ready.
+
+### resonatehq/resonate-on-nats — message broker
+
+[`resonatehq/resonate-on-nats`](https://github.com/resonatehq/resonate-on-nats) is a complete,
+independent reimplementation of the protocol in Go, backed by NATS JetStream (a message broker and
+key-value store). It is source-available under BUSL-1.1 (free for development and evaluation;
+commercial license for production; converts to Apache 2.0 on 2030-07-01).
+
+Each promise's state lives as a single JSON blob per origin in JetStream KV, written with optimistic
+CAS. Its transport is **NATS pub/sub — not HTTP**. Existing Resonate SDKs cannot talk to it without a
+NATS-aware client or bridge. This is not a drop-in backend swap; it is a NATS-native architecture,
+distinct from the HTTP envelope the other two servers share.
+
+This server is experimental — created June 2026, approximately three weeks of development, minimal
+test coverage. It is architecturally elegant and demonstrates the most surprising paradigm leap (a
+message broker as a durable-execution substrate), but it is not a production story today.
+
+### What the spread proves
+
+Relational SQL, wide-column NoSQL, a message broker. Three storage paradigms, three different
+consistency mechanisms (MVCC + WAL, LWT/Paxos, JetStream KV CAS), and in the NATS case a different
+transport entirely. All three implement the same protocol and interoperate with the same SDK layer
+(with the noted NATS exception on transport). The protocol is substrate-independent.
+
+Neither Go server is a plugin to the Rust server. Each independently reimplements the
+protocol specification from scratch. That independence is the point: the spec is the shared contract,
+not the Rust implementation.
+
+## Chapters in this track
+
+Read [/spec](/spec) first if you have not — the protocol semantics are defined there. The SDK track
+([/sdk](/sdk)) documents the other side of the wire: how a client consumes the handlers you are
+implementing.
+
+| Chapter | What you get |
+|---|---|
+| [Abstract machine](/server/abstract-machine) | The Lean 4 model as an implementer's map — state components, effect types, handler shapes, and how to navigate the spec repo as your primary reference. |
+| [State model](/server/state-model) | The five state components (promises, tasks, schedules, timeouts, outbox) and the invariants your storage layer must maintain over them at all times. |
+| [Envelope and transport](/server/envelope-and-transport) | The HTTP/JSON wire format the reference server uses, what is specified versus what is convention, and how a non-HTTP transport relates. |
+| [Implementing promises](/server/implementing-promises) | All five specified promise handlers — `get`, `create`, `settle`, `register_callback`, `register_listener` — and the settlement scrub inlined at all three settlement sites. |
+| [Implementing tasks](/server/implementing-tasks) | All nine specified task handlers from `acquire` through `halt`/`continue`, the version fencing mechanism, and lease semantics. |
+| [Implementing schedules](/server/implementing-schedules) | The three specified schedule handlers, the `nextCron` question, and the catch-up transition for schedules that fire while the server is down. |
+| [Timeouts and projection](/server/timeouts-and-projection) | How the server fires timeout transitions, what projection means (observing settled state before the transition persists), and the implementation ordering that makes projection safe. |
+| [Outbox and delivery](/server/outbox-and-delivery) | The two outbox message types (`execute` and `unblock`), atomic enqueue with their triggering transitions, and delivery guarantees. |
+| [Storage strategies](/server/storage-strategies) | How the three existing servers map spec effects to relational SQL, wide-column CAS, and JetStream KV — and the patterns that generalize to other substrates. |
+| [Testing and conformance](/server/testing-and-conformance) | The invariants your implementation must hold, how to build an oracle-diff harness, fault injection, and the state of the public conformance question. |
+| [Unspecified surface](/server/unspecified-surface) | Everything the spec deliberately leaves open — transport, auth, search, `nextCron`, `expand`, `preload`, operational knobs. Know the boundary before you make it a requirement. |
+
+---
+
+*Verified against [`resonate-specification@83d64c3`](https://github.com/resonatehq/resonate-specification/tree/83d64c3).*

--- a/content/docs/server/index.mdx
+++ b/content/docs/server/index.mdx
@@ -41,20 +41,23 @@ invariants the machine specifies after every handler invocation. That is the ent
 Concretely:
 
 - Every handler the spec defines — `promise.get`, `promise.create`, `promise.settle`,
-  `promise.register_callback`, `promise.register_listener`, `task.acquire`, `task.create`,
-  `task.fence`, `task.heartbeat`, `task.suspend`, `task.fulfill`, `task.release`, `task.halt`,
-  `task.continue`, `schedule.get`, `schedule.create`, `schedule.delete`, plus the internal
-  `resume` and `timeouts` transitions — must behave as the corresponding Lean function specifies.
+  `promise.register_callback`, `promise.register_listener`, `task.get`, `task.create`,
+  `task.acquire`, `task.fence`, `task.heartbeat`, `task.suspend`, `task.fulfill`, `task.release`,
+  `task.halt`, `task.continue`, `schedule.get`, `schedule.create`, `schedule.delete`, plus the
+  internal `resume` and `timeouts` transitions — must behave as the corresponding Lean function
+  specifies. (The three `*.search` handlers also have Lean definitions: `501`, deliberately.)
 - State transitions must be atomic with respect to the spec's state model. A handler either
   completes all its effects or none.
 - The invariants the machine holds over promises, tasks, schedules, timeouts, and the outbox must
   hold after every transition.
 
 What is *not* specified is as important as what is. Transport encoding, authentication, search
-handlers (`promise.search`, `task.search`, `schedule.search` are `501` stubs in the spec),
-cron-expression evaluation, and concurrency limits are intentionally left to the implementer. The spec
-does not require HTTP. It does not require JSON. It does not require any specific storage engine.
-Those decisions are yours. The handlers and their state semantics are not.
+semantics (`promise.search`, `task.search`, `schedule.search` are `501` stubs in the spec),
+cron-expression evaluation, and concurrency limits are intentionally left to the implementer. The
+Lean machine does not model HTTP or JSON at all — though the [prose spec's message-passing
+protocol](/spec/execution-model/message-passing#address-schemes) does name HTTP as the required
+transport, with the envelope encoding defined by the reference server. No specific storage engine is
+required. Those decisions are yours. The handlers and their state semantics are not.
 
 <Callout type="info" title="No public conformance suite yet">
 The mechanism that verifies conformance — an oracle-diff harness that replays operation sequences and
@@ -91,8 +94,8 @@ reference server** (protocol version `2026-04-01`, `kind`-multiplexed POST). Any
 SDK points at it unchanged. It is a true drop-in backend swap.
 
 This is an official Resonate HQ project (not a community fork), actively developed. Its test rigor is
-exceptional: oracle-diff against the reference server, random-kill fault injection across 51 named
-invariants, and Porcupine linearizability verification. It is not yet at 1.0 and has known open
+exceptional: oracle-diff against the reference server, random-kill fault injection across 53 named
+invariants (at the time of writing), and Porcupine linearizability verification. It is not yet at 1.0 and has known open
 issues. Label it accordingly — most credible non-reference production story, not yet production-ready.
 
 ### resonatehq/resonate-on-nats — message broker

--- a/content/docs/server/meta.json
+++ b/content/docs/server/meta.json
@@ -1,5 +1,24 @@
 {
   "root": true,
   "title": "Build a server",
-  "pages": ["index"]
+  "pages": [
+    "index",
+    "---The machine---",
+    "abstract-machine",
+    "state-model",
+    "---The wire---",
+    "envelope-and-transport",
+    "---The handlers---",
+    "implementing-promises",
+    "implementing-tasks",
+    "implementing-schedules",
+    "---Internal transitions---",
+    "timeouts-and-projection",
+    "outbox-and-delivery",
+    "---Production wedge---",
+    "storage-strategies",
+    "testing-and-conformance",
+    "---Boundaries---",
+    "unspecified-surface"
+  ]
 }

--- a/content/docs/server/outbox-and-delivery.mdx
+++ b/content/docs/server/outbox-and-delivery.mdx
@@ -77,7 +77,7 @@ structure ServerConfig where
 
 ## Full enumeration of enqueue sites
 
-These are every spec handler that calls `setMessage`, verified against the Lean files:
+These are every spec handler that *directly* calls `setMessage`, verified against the Lean files. Two handlers also produce messages **transitively**: `task.fence` (T-04) delegates to the full `promiseCreate`/`promiseSettle` handlers, and `onScheduleTimeout`'s catchUp loop calls `promiseCreate` for each fired occurrence — so both inherit those handlers' enqueue behavior, and both must run inside the same transaction scope as the delegated handler's writes:
 
 ### Execute messages
 

--- a/content/docs/server/outbox-and-delivery.mdx
+++ b/content/docs/server/outbox-and-delivery.mdx
@@ -1,0 +1,192 @@
+---
+title: "Outbox and delivery"
+pageTitle: "The outbox and message delivery"
+description: "How the server's outbox — part of machine state, not an implementation detail — drives task dispatch and promise unblocking with exactly-two message types and at-least-once delivery."
+hideTitle: true
+---
+
+# The outbox and message delivery
+
+The outbox is not a queue you bolt on after you get the state machine working. It is a field of [`ServerState`](https://github.com/resonatehq/resonate-specification/blob/main/spec/01-objects/state.lean) — the same struct that holds promises, tasks, and schedules — and its entries are written by the same handlers that write state transitions. If your outbox row doesn't commit atomically with the state change that caused it, you have a bug.
+
+```lean
+-- spec/01-objects/state.lean
+structure ServerState where
+  config           : ServerConfig         := {}
+  promises         : List PromiseObject
+  tasks            : List TaskObject
+  ...
+  outbox           : List OutboxEntry     := []
+```
+
+That placement is intentional. The outbox is the server's declaration of what *must* be delivered to the outside world. It says what is pending; the transport says what has been sent. Keeping those two concerns separate is the entire architecture of reliable dispatch.
+
+## Two message types, nothing else
+
+The spec defines exactly two messages:
+
+```lean
+-- spec/01-objects/state.lean:78–81
+inductive Message
+  | execute (taskId : String) (version : Nat)
+  | unblock (promise : PromiseRecord)
+```
+
+**`execute (taskId, version)`** tells a target address to acquire and run a specific task. The version is the current fencing token — not a hint to increment, just the version the worker must present to `task.acquire`. A worker that receives this, acquires successfully, and finds its version stale has already been superseded; it should stop.
+
+**`unblock (promise)`** tells a listener address that a promise they registered on has settled. It carries the full settled promise record — state, value, tags — so the recipient can act without a round-trip fetch.
+
+There is no third type. There is no "heartbeat message" or "cancel message" flowing through the outbox.
+
+## `setMessage` is an upsert
+
+Every enqueue goes through one function:
+
+```lean
+-- spec/01-objects/state.lean:166–170
+def setMessage (address : String) (msg : Message) : M Unit :=
+  modify fun s =>
+    let entry := OutboxEntry.mk address msg
+    let key   := entry.key
+    { s with outbox := entry :: s.outbox.filter (fun e => e.key != key) }
+```
+
+This is a keyed upsert: drop any existing entry with the same key, prepend the new one. Keys are defined as:
+
+```lean
+-- spec/01-objects/state.lean:88–90
+def OutboxEntry.key : OutboxEntry → String
+  | { message := .execute taskId _,  .. } => taskId
+  | { address, message := .unblock p }    => s!"{p.id}:notify:{address}"
+```
+
+**For execute:** keyed by `taskId` alone. Two executes for the same task collapse into one — the later write wins. This is safe: if the retry timeout fires and enqueues a second execute before the first is delivered, the worker will see only one (with the most current version). A stale duplicate from before the upsert has already been dropped.
+
+**For unblock:** keyed by `"{promiseId}:notify:{address}"`. A given (promise, listener) pair produces at most one pending unblock in the outbox. If the promise settles and the listener is registered twice (which `addListener` prevents, but the upsert is the backstop), only one outbox entry exists.
+
+## `retryTimeout` — the re-dispatch cadence
+
+[`ServerConfig`](https://github.com/resonatehq/resonate-specification/blob/main/spec/01-objects/state.lean) carries one field that governs how quickly the server re-offers a task:
+
+```lean
+structure ServerConfig where
+  retryTimeout : Nat := 5000   -- milliseconds
+```
+
+`retryTimeout` is the interval at which a `pending` task re-emits its execute message if no worker has claimed it. Every handler that enqueues an execute also arms a retry-timeout at `now + retryTimeout`. That timeout fires `onTaskRetryTimeout`, which re-emits the execute and arms the timeout again — an automatic re-dispatch loop until a worker acquires the task or the promise is settled.
+
+## Full enumeration of enqueue sites
+
+These are every spec handler that calls `setMessage`, verified against the Lean files:
+
+### Execute messages
+
+| Transition | Handler | Lean file |
+|---|---|---|
+| Promise created with `resonate:target` (no delay, or elapsed delay) | `promiseCreate` | [`P-02-promise.create.lean`](https://github.com/resonatehq/resonate-specification/blob/main/spec/02-actions/P-02-promise.create.lean) |
+| Worker releases an acquired task | `taskRelease` | [`T-08-task.release.lean`](https://github.com/resonatehq/resonate-specification/blob/main/spec/02-actions/T-08-task.release.lean) |
+| Halted task resumed by operator | `taskContinue` | [`T-10-task.continue.lean`](https://github.com/resonatehq/resonate-specification/blob/main/spec/02-actions/T-10-task.continue.lean) |
+| Pending task's retry timeout fires | `onTaskRetryTimeout` | [`02-timeouts.lean`](https://github.com/resonatehq/resonate-specification/blob/main/spec/02-actions/02-timeouts.lean) |
+| Acquired task's lease expires | `onTaskLeaseTimeout` | [`02-timeouts.lean`](https://github.com/resonatehq/resonate-specification/blob/main/spec/02-actions/02-timeouts.lean) |
+| Awaited promise settles, suspended task wakes | `enqueueResume` | [`00-resume.lean`](https://github.com/resonatehq/resonate-specification/blob/main/spec/02-actions/00-resume.lean) |
+
+### Unblock messages
+
+| Transition | Handler | Lean file |
+|---|---|---|
+| Promise settled via `promise.settle` | `promiseSettle` | [`P-03-promise.settle.lean`](https://github.com/resonatehq/resonate-specification/blob/main/spec/02-actions/P-03-promise.settle.lean) |
+| Promise settled via `task.fulfill` | `taskFulfill` | [`T-07-task.fulfill.lean`](https://github.com/resonatehq/resonate-specification/blob/main/spec/02-actions/T-07-task.fulfill.lean) |
+| Promise timed out | `onPromiseTimeout` | [`02-timeouts.lean`](https://github.com/resonatehq/resonate-specification/blob/main/spec/02-actions/02-timeouts.lean) |
+
+All three settlement paths iterate `p.listeners` and call `setMessage address (.unblock p.toRecord)` for each registered listener. All three also call `enqueueResume` for each registered callback — which may produce additional execute messages if the awaiting task was suspended. Miss the `task.fulfill` path and a promise settled through T-07 notifies no one — no error, no signal, just listeners that never fire.
+
+One enqueue site that does **not** send a message: `promise.create` with a `resonate:delay` tag whose deadline has not yet elapsed. The task is created in `pending` and a retry timeout is armed, but no execute is sent immediately — the first dispatch waits for `onTaskRetryTimeout` to fire at the delay instant. This is a named tag behavior, not general spec machinery.
+
+One more: `task.create` creates the task in `acquired` (the calling worker already holds it) and writes no execute to the outbox. The execute appears later, when `task.release` or a timeout transitions the task back to `pending`.
+
+## The resume chain
+
+`enqueueResume` handles the case where an awaited promise settles and the task that was waiting on it needs to be woken:
+
+```lean
+-- spec/02-actions/00-resume.lean
+def enqueueResume (awaitedId awaiterId : String) (now : Nat) : M Unit := do
+  let some t ← getTask awaiterId | pure ()
+  match t.state with
+  | .suspended =>
+      let retryTimeout := (← get).config.retryTimeout
+      let t := { t with state := .pending, resumes := [awaitedId] }
+      setTask t
+      setTaskTimeout t.id 0 (now + retryTimeout)
+      match ← getPromise awaiterId with
+      | none => pure ()
+      | some p =>
+          let target := (p.tags.get? "resonate:target").getD ""
+          if target != "" then
+            setMessage target (.execute t.id t.version)
+  | .pending | .acquired | .halted =>
+      if t.resumes.contains awaitedId then pure ()
+      else setTask { t with resumes := t.resumes ++ [awaitedId] }
+  | .fulfilled => pure ()
+```
+
+Three things worth noting:
+
+**Version is not bumped.** `enqueueResume` sends `(.execute t.id t.version)` — the current version, not an incremented one. The spec comment is explicit: a resume re-emits the current version as a wake-up hint. The version only advances on `task.acquire`. See [tasks and the worker loop](/sdk/tasks-and-the-worker-loop).
+
+**Non-suspended states buffer.** If the task is `pending`, `acquired`, or `halted` when its awaited promise settles, `enqueueResume` doesn't send anything — it appends `awaitedId` to `t.resumes` (deduplicated). The task already has something driving it; the settled promise is recorded and will be visible when the driver next inspects state. If the task is `fulfilled`, it's a no-op.
+
+**Empty target sends nothing.** If the promise's `resonate:target` tag is absent or empty, `enqueueResume` transitions the task to `pending` and arms the retry timeout, but skips the execute. This means a polling worker that re-acquires via `task.acquire` (bypassing push entirely) will still find the task — the retry timeout will re-offer it — but no push message is sent.
+
+<Callout type="caution" title="Suspended tasks have no retry timeout">
+A suspended task carries no task timeout (invariant 6 in the [spec's task model](/spec/system-model/tasks)). The retry timeout is armed only when `enqueueResume` transitions the task to `pending`. Before that, the task is parked indefinitely, waiting on a settlement. This is correct and expected: the wakeup is event-driven, not timer-driven. If the awaited promise never settles (e.g., an eternal external promise), the suspended task waits forever — which is intentional. Timer promises exist precisely to bound that wait. See [timeouts and projection](/server/timeouts-and-projection).
+</Callout>
+
+## Implementation shape: atomic commit, then drain
+
+The outbox only works if the outbox row commits in the same transaction as the state change that caused it. If you write the state, commit, then write the outbox, a crash between the two leaves a task pending with no pending delivery — the task re-surfaces only if a timeout fires later, if one was armed. If you write the outbox and crash before committing the state change, the row is orphaned (benign but noisy). Atomicity is the correct direction.
+
+The reference server (Apache-2.0, [`resonate`](https://github.com/resonatehq/resonate)) implements this in its SQLite and Postgres persistence layers. Every handler runs inside a database transaction (`unchecked_transaction()` → `commit()` in `persistence_sqlite.rs`). The `INSERT INTO outgoing_execute` and `INSERT INTO outgoing_unblock` statements run inside that same transaction, alongside the promise/task/timeout updates. A background delivery loop then drains the outbox:
+
+```rust
+// resonate/src/processing/processing_messages.rs
+let (execute_msgs, unblock_msgs) = storage
+    .transact(move |db| db.take_outgoing(batch_size))
+    .await?;
+```
+
+`take_outgoing` uses `DELETE ... RETURNING` — it atomically removes and returns a batch of rows. This means a message is consumed exactly once by the delivery loop; if the loop crashes after deleting but before delivering, the message is lost. The transport must be prepared to re-send if an upstream retry fires — and the worker must tolerate duplicate executes. See [tasks and the worker loop](/sdk/tasks-and-the-worker-loop) for the version-based deduplication that makes receiving the same execute twice safe.
+
+The loop runs on a configurable `poll_interval` and `batch_size` from the server config. Neither is specified by the DAA protocol — they are reference-server operational parameters. The unblock delivery follows the same pattern.
+
+<Callout type="note" title="At-least-once is the transport's job">
+The spec defines what belongs in the outbox and when. It does not define how deliveries are retried if the network is down when the loop drains a batch. The reference server's delivery loop is fire-and-forget per batch: it deletes the rows, dispatches, and moves on. Retry, backoff, and transport-level deduplication are implementation concerns above the spec floor. The retry timeout (`onTaskRetryTimeout`) re-enqueues execute messages for tasks that were never acquired — so for execute, the spec itself provides a recovery path at the cost of `retryTimeout` latency. For unblock, a listener that misses its delivery window has no built-in recovery; the listener address is the worker's responsibility to keep alive.
+</Callout>
+
+## Wire shape
+
+The reference server serializes execute messages as:
+
+```json
+{
+  "kind": "execute",
+  "head": { "serverUrl": "https://my-server.example.com" },
+  "data": { "task": { "id": "my-task-id", "version": 3 } }
+}
+```
+
+And unblock messages as:
+
+```json
+{
+  "kind": "unblock",
+  "head": {},
+  "data": { "promise": { "id": "...", "state": "resolved", ... } }
+}
+```
+
+The wire encoding and address format are transport-specific and unspecified by the DAA protocol. For address semantics and the full picture of delivery on the wire, see [message passing](/spec/execution-model/message-passing). For how to implement the task side of this flow, see [implementing tasks](/server/implementing-tasks).
+
+---
+
+*Verified against [resonate-specification`@83d64c3`](https://github.com/resonatehq/resonate-specification/tree/83d64c3).*

--- a/content/docs/server/state-model.mdx
+++ b/content/docs/server/state-model.mdx
@@ -1,0 +1,166 @@
+---
+title: "State model"
+pageTitle: "State model: records, enums, and internal fields"
+description: "The exact structure of every object in ServerState — PromiseObject, TaskObject, Schedule, timeout lists, and outbox — including which fields appear on the wire and which are internal-only."
+hideTitle: true
+---
+
+# State model: records, enums, and internal fields
+
+The [abstract machine](/server/abstract-machine) holds all its knowledge in a single `ServerState`. This chapter walks every component of that state: the records, their fields, which fields cross the wire, and which are internal implementation details the spec uses but never exposes to callers.
+
+The canonical source for everything here is [`spec/01-objects/types.lean`](https://github.com/resonatehq/resonate-specification/blob/main/spec/01-objects/types.lean) (wire records and enums) and [`spec/01-objects/state.lean`](https://github.com/resonatehq/resonate-specification/blob/main/spec/01-objects/state.lean) (internal objects, effects, and `ServerState`). Read these files directly when a detail matters for your implementation.
+
+## Two levels: internal objects and wire records
+
+The spec defines two shapes for each entity:
+
+- **Internal object** (`PromiseObject`, `TaskObject`) — what the machine stores. Contains all fields including ones that are never serialized.
+- **Wire record** (`PromiseRecord`, `TaskRecord`) — what appears in request/response bodies. A strict subset of the internal object.
+
+The conversion is explicit. `PromiseObject.toRecord` strips `callbacks` and `listeners`. `TaskObject.toRecord` strips `resumes` (as a `List String`) and replaces it with `resumes.length` (a count). If you store more than the wire record in your database, those extra fields are implementation internals that callers will never see and must never rely on.
+
+## Promises
+
+### PromiseState
+
+```text
+pending | resolved | rejected | rejectedCanceled | rejectedTimedout
+```
+
+Five variants. A promise starts `pending` and moves to exactly one terminal state. The two `rejected*` variants distinguish a caller-initiated rejection (`rejected`), an administrative cancellation (`rejectedCanceled`), and a timeout expiry (`rejectedTimedout`). `resolved` is the success terminal. See the [durable promise specification](/spec/programming-model/durable-promise-specification) for the semantics of each state.
+
+### PromiseRecord (wire-visible)
+
+| Field | Type | Meaning |
+|---|---|---|
+| `id` | `String` | Unique promise identifier |
+| `state` | `PromiseState` | Current state |
+| `param` | `Value` | Input value set at creation; immutable |
+| `value` | `Value` | Output value; meaningful only when settled |
+| `tags` | `Tags` | Key-value pairs; `resonate:target` and `resonate:timer` drive machine behavior |
+| `timeoutAt` | `Nat` | Unix ms deadline; past this instant a pending promise is *projected* as already settled |
+| `createdAt` | `Nat` | Unix ms creation timestamp |
+| `settledAt` | `Option Nat` | Unix ms settlement timestamp; `none` while pending |
+
+`Value` is `{ headers : Tags, data : Option String }`. `Tags` is `List (String × String)`. Both appear on the wire as-is.
+
+### PromiseObject (internal — adds two fields)
+
+| Field | Type | Wire-visible? | Meaning |
+|---|---|---|---|
+| *(all PromiseRecord fields)* | — | Yes | See above |
+| `callbacks` | `List String` | **No** | Awaiter promise IDs registered on this promise; flushed and replaced with resume messages when the promise settles |
+| `listeners` | `List String` | **No** | Addresses subscribed for an `unblock` message when the promise settles |
+
+`callbacks` holds promise IDs, not task IDs. When a task suspends waiting for a promise to settle, the server adds the *awaiter's promise ID* (which equals the awaiter's task ID) to the awaited promise's `callbacks` list. `listeners` holds delivery addresses (strings). Both lists are deduplicated: adding an entry that already exists is a no-op.
+
+### External and timer promises
+
+Two predicate functions on `PromiseObject` matter throughout the machine:
+
+- **External promise**: `p.tags.has "resonate:target" || p.isTimer` — a promise that triggers work outside the machine (a worker execution or a timer). External promises always have a corresponding task.
+- **Timer promise**: `p.tags.get? "resonate:timer" == some "true"` — a special external promise that settles `resolved` (not `rejectedTimedout`) when its `timeoutAt` elapses.
+
+See [tasks](/spec/system-model/tasks) for how `resonate:target` causes a task and an execute message to be created alongside the promise.
+
+## Tasks
+
+### TaskState
+
+```text
+pending | acquired | suspended | halted | fulfilled
+```
+
+Five variants. `fulfilled` is the only terminal state; `halted` is an administrative state that a task enters via `task.halt` and leaves via `task.continue` (which returns it to `pending`). A task in `halted` is out of circulation: it holds no lease and no retry timeout. Your monitoring should surface halted tasks explicitly — they will not self-recover.
+
+### TaskRecord (wire-visible)
+
+| Field | Type | Wire-visible? | Meaning |
+|---|---|---|---|
+| `id` | `String` | Yes | Task identifier; equals its promise's id |
+| `state` | `TaskState` | Yes | Current state |
+| `version` | `Nat` | Yes | Fencing token; increments on each `task.acquire` |
+| `resumes` | `Nat` | Yes | **Count only** — number of buffered settled-awaited IDs |
+| `ttl` | `Option Nat` | Yes | Lease deadline (Unix ms); `none` when not acquired |
+| `pid` | `Option String` | Yes | Worker process ID holding the lease; `none` when not acquired |
+
+### TaskObject (internal — `resumes` is richer)
+
+| Field | Type | Wire-visible? | Meaning |
+|---|---|---|---|
+| *(all TaskRecord fields except `resumes`)* | — | Yes | See above |
+| `resumes` | `List String` | **No** (exposed as `.length`) | Settled promise IDs that triggered this task's re-pending while it was suspended, pending, acquired, or halted; deduplicated |
+
+The `resumes` divergence is the sharpest difference between the two levels. On the wire, `resumes` is a count — a worker can observe that multiple settlements fired while it was away but cannot see which ones without looking up the awaited promises individually. Internally, the machine stores the actual IDs so that `enqueueResume` can deduplicate.
+
+### Version and lease
+
+**Version** (`version : Nat`) is the fencing token. It increments on every `pending→acquired` transition — in `task.acquire` (see [`T-03-task.acquire.lean`](https://github.com/resonatehq/resonate-specification/blob/main/spec/02-actions/T-03-task.acquire.lean)) and in the re-acquire branch of `task.create` ([`T-02-task.create.lean`](https://github.com/resonatehq/resonate-specification/blob/main/spec/02-actions/T-02-task.create.lean)). No other operation changes it. A task returning to `pending` after a lease expiry or a `task.release` keeps its current version; the next `task.acquire` bumps it. Every mutating operation on a task (`fence`, `suspend`, `fulfill`, `release`) must present the current version and receives `409` if the version has moved on. This is how a stale worker's writes are rejected.
+
+**Lease** is `ttl`+`pid` together. `ttl` is the Unix ms deadline after which the server considers the worker dead; `pid` identifies which worker holds it. Both are `none` when a task is not acquired. Both are set on `task.acquire` and cleared on `task.suspend` (the task parks without a lease; it is woken by settlement, not by a clock). A lease timeout fires `onTaskLeaseTimeout`, which returns the task to `pending`, clears `ttl` and `pid`, and re-enqueues an execute message — all without advancing the version.
+
+<Callout type="caution" title="Version advances on acquire, not on lease expiry">
+The machine carries a task back to `pending` at its current version when the lease lapses. The version advances on the *next* `task.acquire`. A test that asserts "version incremented the instant the lease expired" will fail against a correct implementation. Assert instead that once any worker re-acquires, the version is strictly greater than what the previous holder saw.
+</Callout>
+
+## Schedules
+
+A `Schedule` is a recurring cron rule. The machine stores it as a single record with no internal-only variant:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `id` | `String` | Schedule identifier |
+| `cron` | `String` | Cron expression (implementation-defined interpretation via `opaque nextCron`) |
+| `promiseId` | `String` | Template for promise IDs created at each fire; expanded via `opaque expand` |
+| `promiseTimeout` | `Nat` | `timeoutAt` offset (ms) applied to each created promise |
+| `promiseParam` | `Value` | `param` for each created promise |
+| `promiseTags` | `Tags` | `tags` for each created promise |
+| `nextRunAt` | `Nat` | Unix ms of next scheduled fire |
+| `lastRunAt` | `Option Nat` | Unix ms of last fire; `none` before the first |
+| `createdAt` | `Nat` | Unix ms creation timestamp |
+
+Each schedule carries its own timeout entry. When that timeout fires, `onScheduleTimeout` calls `catchUp` — which loops, creating promises for every missed fire since the last run, advancing `nextRunAt` after each one, until the schedule is current. See [timeouts and projection](/server/timeouts-and-projection) for the full catchUp semantics.
+
+## Timeout lists
+
+`ServerState` has three timeout lists. Each entry is a `(id, timeout)` pair the environment is expected to fire when `now ≥ timeout`:
+
+| List | Entry type | `kind` field | When fired |
+|---|---|---|---|
+| `promiseTimeouts` | `PromiseTimeout` | — | Settles a pending promise as `rejectedTimedout` (or `resolved` for timers) |
+| `taskTimeouts` | `TaskTimeout` | `0` = retry, `1` = lease | `0`: re-enqueues an execute for a pending task; `1`: expires an acquired task's lease |
+| `scheduleTimeouts` | `ScheduleTimeout` | — | Fires a schedule, creating promises for all missed intervals (catchUp) |
+
+The `kind` field on `TaskTimeout` is the only place where a single list entry encodes two distinct behaviors. A pending task has a retry timeout (`kind=0`): if no worker acquires it within `retryTimeout` ms (default 5000), the server re-enqueues the execute message. An acquired task has a lease timeout (`kind=1`): if no heartbeat refreshes it in time, the server evicts the worker. These are separate entries — a task may have both simultaneously only transiently. See [timeouts and projection](/server/timeouts-and-projection) for how projection interacts with both.
+
+## Outbox
+
+`outbox : List OutboxEntry` is the machine's pending delivery queue. Each entry is:
+
+```lean
+structure OutboxEntry where
+  address : String
+  message : Message   -- execute (taskId version) | unblock (promise : PromiseRecord)
+```
+
+Two message types exist:
+
+- **`execute taskId version`** — dispatches a task to a worker at `address`. Carries the task's *current* version (not incremented by the enqueue; the next acquire will increment it).
+- **`unblock promise`** — notifies a listener at `address` that a promise has settled. Carries the settled `PromiseRecord`.
+
+Outbox entries are keyed: `setMessage` deduplicates by `taskId` for execute messages, and by `"{promiseId}:notify:{address}"` for unblock messages. A handler that enqueues the same message twice leaves only one entry. Your delivery layer reads and drains the outbox; the spec says nothing about delivery guarantees or ordering beyond the keying rule. See [outbox and delivery](/server/outbox-and-delivery) for implementation strategies.
+
+## Cross-reference
+
+The objects defined here appear throughout the prose specification:
+
+- Promise lifecycle and promise states: [durable promise specification](/spec/programming-model/durable-promise-specification)
+- Task lifecycle, invariants, and version semantics: [tasks](/spec/system-model/tasks)
+- How timeout projection makes a pending-but-expired promise read as already settled: [timeouts and projection](/server/timeouts-and-projection)
+
+The abstract machine chapter preceding this one covers `M`, effects, and handler structure: [abstract machine](/server/abstract-machine).
+
+---
+
+*Verified against [`resonate-specification@83d64c3`](https://github.com/resonatehq/resonate-specification/tree/83d64c3).*

--- a/content/docs/server/state-model.mdx
+++ b/content/docs/server/state-model.mdx
@@ -28,7 +28,7 @@ The conversion is explicit. `PromiseObject.toRecord` strips `callbacks` and `lis
 pending | resolved | rejected | rejectedCanceled | rejectedTimedout
 ```
 
-Five variants. A promise starts `pending` and moves to exactly one terminal state. The two `rejected*` variants distinguish a caller-initiated rejection (`rejected`), an administrative cancellation (`rejectedCanceled`), and a timeout expiry (`rejectedTimedout`). `resolved` is the success terminal. See the [durable promise specification](/spec/programming-model/durable-promise-specification) for the semantics of each state.
+Five variants. A promise starts `pending` and moves to exactly one terminal state. The three `rejected*` variants distinguish a caller-initiated rejection (`rejected`), an administrative cancellation (`rejectedCanceled`), and a timeout expiry (`rejectedTimedout`). `resolved` is the success terminal. See the [durable promise specification](/spec/programming-model/durable-promise-specification) for the semantics of each state.
 
 ### PromiseRecord (wire-visible)
 
@@ -132,7 +132,7 @@ Each schedule carries its own timeout entry. When that timeout fires, `onSchedul
 | `taskTimeouts` | `TaskTimeout` | `0` = retry, `1` = lease | `0`: re-enqueues an execute for a pending task; `1`: expires an acquired task's lease |
 | `scheduleTimeouts` | `ScheduleTimeout` | — | Fires a schedule, creating promises for all missed intervals (catchUp) |
 
-The `kind` field on `TaskTimeout` is the only place where a single list entry encodes two distinct behaviors. A pending task has a retry timeout (`kind=0`): if no worker acquires it within `retryTimeout` ms (default 5000), the server re-enqueues the execute message. An acquired task has a lease timeout (`kind=1`): if no heartbeat refreshes it in time, the server evicts the worker. These are separate entries — a task may have both simultaneously only transiently. See [timeouts and projection](/server/timeouts-and-projection) for how projection interacts with both.
+The `kind` field on `TaskTimeout` is the only place where a single list encodes two distinct behaviors. A pending task has a retry timeout (`kind=0`): if no worker acquires it within `retryTimeout` ms (default 5000), the server re-enqueues the execute message. An acquired task has a lease timeout (`kind=1`): if no heartbeat refreshes it in time, the server evicts the worker. The two kinds are always exclusive — a pending task carries exactly one `kind=0` entry, an acquired task exactly one `kind=1` entry, and other states carry none; `delTaskTimeout` (which removes all entries for an id regardless of kind) always runs before `setTaskTimeout` in every handler that transitions between these states, so both kinds are never present at once. See [timeouts and projection](/server/timeouts-and-projection) for how projection interacts with both.
 
 ## Outbox
 

--- a/content/docs/server/storage-strategies.mdx
+++ b/content/docs/server/storage-strategies.mdx
@@ -74,7 +74,7 @@ schedules         — id, cron, promise_id, promise_timeout, …
 schedule_timeouts — timeout_at (indexed ASC), id
 ```
 
-Tasks and promises share the same primary key — a task is an extension of its promise, not a separate entity. The `tasks.version` column is the fencing token; every mutating task operation issues a conditional `UPDATE tasks SET version = version + 1 WHERE id = ? AND version = ?` (or equivalent CTE) inside a transaction. Stale version → no rows updated → the handler returns `409`.
+Tasks and promises share the same primary key — a task is an extension of its promise, not a separate entity. The `tasks.version` column is the fencing token, used in two distinct patterns. Acquire transitions (`task.acquire`, and `task.create`'s re-acquire branch) are the only mutations that increment it: `UPDATE tasks SET state = 'acquired', version = version + 1, pid = ?, ttl = ? WHERE id = ? AND version = ?`. Every other version-fenced mutation (`fence`, `suspend`, `fulfill`, `release`) checks without bumping: `UPDATE tasks SET state = ?, … WHERE id = ? AND version = ?`. Either way, stale version → no rows updated → the handler returns `409`.
 
 SQLite runs with WAL mode, `busy_timeout = 5000`, and `foreign_keys = ON`. WAL allows concurrent readers while a writer holds the lock; `busy_timeout` absorbs transient write contention without an immediate error.
 
@@ -84,7 +84,7 @@ SQLite runs with WAL mode, `busy_timeout = 5000`, and `foreign_keys = ON`. WAL a
 
 ### Serialization errors
 
-Postgres (and MySQL) can return serialization errors (`SQLSTATE 40001`) or deadlock errors (`40P01`) on concurrent transactions. The `From<sqlx::Error>` implementation converts these to `StorageError::Serialization`, which the handler layer maps to `503` (retriable, nothing was committed). SQLite avoids this category with its single-writer model.
+Postgres (and MySQL) can return serialization errors (`SQLSTATE 40001`) or deadlock errors (`40P01`) on concurrent transactions. The `From<sqlx::Error>` implementation converts these to `StorageError::Serialization` — documented in `persistence/mod.rs` as "retries exhausted, nothing was committed." Note: the handler layer currently surfaces this as a generic `500`; a distinct retriable `503` is the documented design intent but is not yet implemented in `server.rs`. SQLite avoids this category with its single-writer model.
 
 <Callout type="caution" title="MySQL's VARCHAR(255) limit">
 The MySQL backend maps storage-level constraint violations (oversized field values against `VARCHAR(255)` columns) to `StorageError::InvalidInput`, which becomes `400`. If you are implementing a MySQL backend, size constraints are a real sharp edge: a client that sends a promise id longer than 255 bytes will receive `400`, not `500`. Test this path explicitly.
@@ -191,7 +191,7 @@ If you are implementing storage from scratch, verify each of the following befor
 
 5. **Timeout scan** — you must be able to find all promises, tasks, and schedules whose `timeout_at <= now` without scanning the full dataset. A time-ordered index or a bucket-partitioned time table both work.
 
-6. **Serialization error propagation** — on a lost CAS or a transaction conflict, the handler must return `503` (retriable, nothing committed) to the caller — not `500`, not a silent empty response. The `503` code is a reference-server convention, not part of the Lean model's status vocabulary; see [the status-code table](/server/envelope-and-transport).
+6. **Serialization error propagation** — on a lost CAS or a transaction conflict, fail the whole handler with nothing committed and surface a retriable error to the caller — never a silent empty response, and never a success. Neither the Lean model nor the reference server defines a distinct retriable status today (the reference server surfaces these as `500`; a distinct `503` is its documented design intent) — what matters is that your error is distinguishable and the caller can safely retry. See [the status-code table](/server/envelope-and-transport).
 
 <Callout type="info" title="Timeout scan and multi-record atomicity are the two that bite first">
 Developers who implement storage in layers typically get durability and idempotent creates right early on. The first real pain arrives when a timeout scan starts reading the full table at scale, and the second arrives when a promise settlement commits without writing its callback notifications. Build both correctly from the start rather than retrofitting them.

--- a/content/docs/server/storage-strategies.mdx
+++ b/content/docs/server/storage-strategies.mdx
@@ -1,0 +1,211 @@
+---
+title: "Storage strategies"
+pageTitle: "Storage strategies: backing a DAA server"
+description: "The substrate requirements every DAA server storage layer must meet, with three worked case studies: relational SQL, wide-column NoSQL, and a message-broker KV store."
+hideTitle: true
+---
+
+# Storage strategies: backing a DAA server
+
+The [abstract machine](/server/abstract-machine) defines what a server must do. This chapter is about what you must give it to stand on. Every DAA server stores the same objects — promises, tasks, schedules, callbacks, listeners, outbox messages — and every mutating handler touches them with the same four requirements. Get those requirements right and the mapping to your storage technology is a detail. Get any of them wrong and the machine's safety guarantees evaporate.
+
+## Drop-in vs. not drop-in — read this first
+
+The three public implementations are introduced, with maturity and license labels, in the [track overview](/server) — the fact that matters for this chapter: the reference server and `resonate-on-scylladb` speak the same HTTP/JSON envelope (existing SDKs point at either unchanged), while `resonate-on-nats` speaks NATS pub/sub instead of HTTP and is **not** a drop-in. State that kind of asymmetry clearly in your own implementation's documentation before your users discover it under load.
+
+## What your storage must give you
+
+Four requirements follow directly from the machine.
+
+### 1. Durability before acknowledgment
+
+A handler that returns `200` or `201` has committed. If the process dies the instant after that response leaves the wire, the committed state must survive and be visible to the next request. This rules out in-memory-only stores for any production path — ephemeral state is only safe for testing, and even then your test harness must account for it.
+
+### 2. Atomic compare-and-swap for task mutations
+
+Task mutations — acquire, release, fulfill, suspend — all carry a `version` (fencing token). The version advances only on each fresh `task.acquire`; every subsequent mutation must be gated on the version the worker believes is current. A mutation that presents a stale version must fail without committing.
+
+This is the entire mechanism that prevents two workers from simultaneously driving the same execution. Your storage must expose either:
+
+- **Row-level transactions with a conditional update** (`UPDATE ... WHERE version = $expected`), or
+- **A native CAS primitive** that fails atomically if the expected revision does not match.
+
+A `SELECT` followed by an application-level check followed by an `UPDATE` does not satisfy this requirement. The gap between the read and the write is a window for a concurrent acquire to slip through.
+
+### 3. Multi-record atomicity for handler effects
+
+Many handlers touch more than one row. The most load-bearing case is `task.fulfill`, which must settle the corresponding promise and complete the task — and must do both or neither. A crash between the two writes leaves the machine in a state it cannot recover from on its own.
+
+The same requirement applies to settlement scrub (processing callbacks and listeners when a promise settles) and to the transactional outbox: outbox messages written in the same transaction as the state change they describe, so no state change is ever committed without a corresponding message — and no message is ever committed without a corresponding state change. See [Outbox and delivery](/server/outbox-and-delivery) for the full delivery contract.
+
+### 4. Efficient timeout scans
+
+The machine is full of deadlines: promise `timeout_at`, task retry timeouts, task lease expirations, schedule fire times. Your background worker needs to find expired entries cheaply and process them in order. If your timeout scan is a full table scan it will eventually become your bottleneck.
+
+A time-ordered index on `timeout_at` is the minimum. Wide-column stores without secondary indexes solve this with bucket-partitioned time tables; that pattern trades query flexibility for predictable scan cost.
+
+---
+
+## Case study 1: Relational SQL — how the reference server does it
+
+The reference server (`resonatehq/resonate`, Rust, Apache-2.0) defines all storage operations behind a single `Db` trait (`src/persistence/mod.rs`). The enum `Storage` wraps three backends — `Sqlite`, `Postgres`, `Mysql` — and exposes two entry points to handlers:
+
+```text
+Storage::transact(f)  // wraps f in a transaction; for all mutating handlers
+Storage::query(f)     // read-only; no transaction overhead
+```
+
+Every mutating handler calls `transact`. The closure receives a `&dyn Db` reference and makes all its reads and writes through it. The database transaction commits when the closure returns `Ok`; it rolls back on any error. Handlers never commit partial state.
+
+### Schema shape
+
+The SQLite backend (`src/persistence/persistence_sqlite.rs`) reveals the full object model. Tables of interest:
+
+```text
+promises          — id, state, param_*, value_*, tags, timeout_at, created_at, settled_at
+tasks             — id (FK → promises.id), state, version
+promise_timeouts  — timeout_at (indexed ASC), id
+task_timeouts     — timeout_at (indexed ASC), id, timeout_type, process_id, ttl
+callbacks         — awaited_id, awaiter_id, ready
+listeners         — promise_id, address
+outgoing_execute  — id, version, address
+outgoing_unblock  — promise_id, address
+schedules         — id, cron, promise_id, promise_timeout, …
+schedule_timeouts — timeout_at (indexed ASC), id
+```
+
+Tasks and promises share the same primary key — a task is an extension of its promise, not a separate entity. The `tasks.version` column is the fencing token; every mutating task operation issues a conditional `UPDATE tasks SET version = version + 1 WHERE id = ? AND version = ?` (or equivalent CTE) inside a transaction. Stale version → no rows updated → the handler returns `409`.
+
+SQLite runs with WAL mode, `busy_timeout = 5000`, and `foreign_keys = ON`. WAL allows concurrent readers while a writer holds the lock; `busy_timeout` absorbs transient write contention without an immediate error.
+
+### The outbox
+
+`outgoing_execute` and `outgoing_unblock` are the outbox tables. The reference server drains them with `take_outgoing`, which issues `DELETE ... RETURNING` — it claims and removes a batch in one statement, so there is no window where a message is "claimed" but not yet removed. Delivery is at-most-once from the storage side; the server retries from the transport side on failure. See [Outbox and delivery](/server/outbox-and-delivery).
+
+### Serialization errors
+
+Postgres (and MySQL) can return serialization errors (`SQLSTATE 40001`) or deadlock errors (`40P01`) on concurrent transactions. The `From<sqlx::Error>` implementation converts these to `StorageError::Serialization`, which the handler layer maps to `503` (retriable, nothing was committed). SQLite avoids this category with its single-writer model.
+
+<Callout type="caution" title="MySQL's VARCHAR(255) limit">
+The MySQL backend maps storage-level constraint violations (oversized field values against `VARCHAR(255)` columns) to `StorageError::InvalidInput`, which becomes `400`. If you are implementing a MySQL backend, size constraints are a real sharp edge: a client that sends a promise id longer than 255 bytes will receive `400`, not `500`. Test this path explicitly.
+</Callout>
+
+---
+
+## Case study 2: Wide-column NoSQL — resonate-on-scylladb
+
+`resonatehq/resonate-on-scylladb` is a complete Go reimplementation of the server protocol backed by ScyllaDB. It speaks the same HTTP/JSON envelope as the reference server, so existing SDKs connect to it with no changes.
+
+The schema collapses promises and tasks into a single wide row (`internal/dbms/schema.cql`):
+
+```text
+promises (PRIMARY KEY (origin, id))
+  — state, param_*, value_*, tags, timeout_at, created_at, settled_at
+  — task_state, task_version, task_ttl, task_pid, task_resumes
+  — task_timeout_retry, task_timeout_lease
+  — callbacks (SET<TEXT>), listeners (SET<TEXT>)
+```
+
+Co-locating task and promise in the same row has a direct payoff: a `task.fulfill` that settles the promise and completes the task is a single-row write. There is no multi-table transaction to coordinate, and no partial-commit window.
+
+### CAS via Lightweight Transactions
+
+ScyllaDB does not support multi-row ACID transactions. Instead it offers Lightweight Transactions (LWT) — Paxos-based CAS on a single partition. The server uses this for every conditional operation.
+
+`task.create` for a fresh promise issues:
+
+```cql
+INSERT INTO promises (id, origin, …, task_state, task_version, …)
+VALUES (…)
+IF NOT EXISTS
+```
+
+`task.create` for a re-acquire on an existing pending task issues an `UPDATE ... IF task_state = 'pending'` conditional. If the condition fails the LWT returns `applied = false` and the handler returns `409` to the client — the same semantics the reference server achieves with a conditional SQL update inside a transaction.
+
+The `IF NOT EXISTS` / `IF <condition>` idiom is the CAS primitive. It is atomic within a single partition (one `origin + id` pair). Multi-partition atomicity is not available; the schema is designed so that each handler's critical path fits within one partition.
+
+### Timeout tables
+
+ScyllaDB lacks efficient secondary indexes across arbitrary partition keys, so timeouts use dedicated time-bucket tables:
+
+```text
+promise_timeouts  (PRIMARY KEY ((bucket, shard), timeout_at, origin, promise_id))
+task_timeouts     (PRIMARY KEY ((bucket, shard), timeout_at, timeout_type, origin, task_id))
+schedule_timeouts (PRIMARY KEY ((bucket, shard), timeout_at, origin, schedule_id, create_token))
+```
+
+`bucket` is derived from `timeout_at` by rounding to a configurable width (default `1h`). A background worker scans forward from `now - lookback` across the current and near-future buckets. This gives O(expired entries in window) scan cost rather than O(total rows).
+
+Because ScyllaDB has no transactions spanning the timeout entry and the main promise row, `task.create` pre-inserts the timeout rows *before* the LWT on the main row. If the LWT fails, the server rolls back the orphaned timeout entries. This is a visible pattern in the source (`handler_task.go`, step 2a/2b): pre-insert → LWT → on conflict, clean up orphans.
+
+---
+
+## Case study 3: Message broker — resonate-on-nats
+
+`resonatehq/resonate-on-nats` is a Go reimplementation backed by NATS JetStream KV. It is a **different transport model** from the two cases above: SDKs communicate via NATS subjects, not HTTP. Existing HTTP-based SDKs cannot use it without a NATS-aware client. This is the not-drop-in server.
+
+### State layout: one KV entry per origin
+
+The server partitions state by `origin` — the `resonate:origin` tag value on a promise. All promises, tasks, schedules, callbacks, listeners, and outbox messages for a given origin are serialized into a single JSON blob and stored under one JetStream KV key. A server instance subscribes to a subset of origins (partitions) and processes messages for those origins serially.
+
+```text
+KV key:   base64url(origin)
+KV value: { promises: {…}, tasks: {…}, schedules: {…},
+             callbacks: {…}, listeners: {…},
+             messages: […], timeouts: […] }
+```
+
+Outbox messages sit inside the same blob as the state they describe. Writing the blob commits both simultaneously — no separate outbox table, no partial-commit risk.
+
+### Optimistic CAS via JetStream revision
+
+JetStream KV exposes a per-key revision counter. The server uses it as a CAS token:
+
+```go
+// Create (revision 0 → key does not yet exist)
+newRev, err = kv.Create(ctx, kvKey(origin), data)
+
+// Update (must present current revision)
+newRev, err = kv.Update(ctx, kvKey(origin), data, revision)
+
+// Both return ErrKeyExists / ErrKeyWrongLastSequence on a lost race → ErrCASConflict
+```
+
+On `ErrCASConflict` the server retries: reload state from KV, replay the handler logic, attempt the write again. This is optimistic concurrency — reads are never locked, writes win or retry. Serial-per-origin processing makes conflicts rare in practice (one actor per origin at a time), but the retry path must be correct because concurrent instances can race on the same origin during failover.
+
+This CAS is origin-scoped, not row-scoped. Every write to *any* promise or task within an origin touches the same KV key. That is the tradeoff: no multi-record coordination problem (the whole origin atomically), but contention within a hot origin hits a single CAS bottleneck.
+
+---
+
+## Building a new substrate: what you need
+
+If you are implementing storage from scratch, verify each of the following before considering your layer complete:
+
+1. **Durability** — writes acknowledged to the handler are visible after a process crash and restart. Test by killing the process mid-write and reading back.
+
+2. **Version-fenced task mutations** — `task.acquire`, `task.fulfill`, `task.release`, `task.suspend` must all fail with an observable conflict signal (return value, error code, or exception) when the presented version is not the current version. No read-then-write gap.
+
+3. **Idempotent creates** — `promise.create` and `task.create` must be safe to call twice with the same id. The second call must return the existing record (with a `was_created = false` or equivalent signal), not an error and not a duplicate row.
+
+4. **Atomic scrub + outbox** — settling a promise, processing its callbacks and listeners, and writing the resulting outbox messages must all commit or all fail. A settlement with no outbox entry produces a lost notification. An outbox entry with no settlement produces a phantom notify.
+
+5. **Timeout scan** — you must be able to find all promises, tasks, and schedules whose `timeout_at <= now` without scanning the full dataset. A time-ordered index or a bucket-partitioned time table both work.
+
+6. **Serialization error propagation** — on a lost CAS or a transaction conflict, the handler must return `503` (retriable, nothing committed) to the caller — not `500`, not a silent empty response. The `503` code is a reference-server convention, not part of the Lean model's status vocabulary; see [the status-code table](/server/envelope-and-transport).
+
+<Callout type="info" title="Timeout scan and multi-record atomicity are the two that bite first">
+Developers who implement storage in layers typically get durability and idempotent creates right early on. The first real pain arrives when a timeout scan starts reading the full table at scale, and the second arrives when a promise settlement commits without writing its callback notifications. Build both correctly from the start rather than retrofitting them.
+</Callout>
+
+Once your storage layer passes basic handler tests, the conformance question becomes: does your server behave identically to the reference server across the full operation space — including corner cases like born-expired promises, concurrent acquires, and lease-lapsed re-claims? See [Testing and conformance](/server/testing-and-conformance) for how to structure that verification.
+
+### Related chapters
+
+- [Abstract machine](/server/abstract-machine) — the state transitions your storage must durably record
+- [Outbox and delivery](/server/outbox-and-delivery) — the full transactional outbox contract and delivery semantics
+- [Envelope and transport](/server/envelope-and-transport) — how the HTTP/JSON envelope maps to storage reads and writes
+- [Testing and conformance](/server/testing-and-conformance) — how to know your storage layer got it right
+
+---
+
+*Verified against [resonate-specification`@83d64c3`](https://github.com/resonatehq/resonate-specification/tree/83d64c3). Reference server source verified against `resonatehq/resonate` `@c8d7c7b`. ScyllaDB and NATS implementations verified from public repository READMEs, CQL schema, and Go source (`internal/dbms/schema.cql`, `internal/core/handler_task.go`, `internal/store.go`) fetched via GitHub API.*

--- a/content/docs/server/testing-and-conformance.mdx
+++ b/content/docs/server/testing-and-conformance.mdx
@@ -43,10 +43,10 @@ The [`resonatehq/resonate-specification`](https://github.com/resonatehq/resonate
 
 ## Reference-server debug endpoints
 
-The reference server exposes five debug endpoints, all handled in `oracle.rs`. They are reference-server tooling — they are not defined by the Lean spec — but they work against any server that implements them, and they are the primitives that make seeded simulation tractable.
+The reference server exposes five debug endpoints, implemented in `src/server.rs`; the `Oracle` struct in `src/oracle.rs` implements the same five independently, for use in oracle-diff testing. They are reference-server tooling — they are not defined by the Lean spec — but they work against any server that implements them, and they are the primitives that make seeded simulation tractable.
 
 **`debug.start` / `debug.stop`**  
-Return `200 {}` and change nothing. Use them to bracket a test scenario: send `debug.start` before the first operation, `debug.stop` after the last assertion. In the oracle they are explicit no-ops (lines 130–135 of `oracle.rs`); in the full server they can toggle debug-mode routing if you wire that up.
+Use them to bracket a test scenario: send `debug.start` before the first operation, `debug.stop` after the last assertion. In the oracle they are explicit no-ops returning `200 {}`; in the running reference server they pause and resume the background processing loops (timeout firing, message delivery) so a test can control when those effects happen.
 
 **`debug.reset`**  
 Clears all state — promises, tasks, schedules, all timeout queues, the outbox. Returns `200 {}`. Call this between test cases to get a clean slate without restarting the process.
@@ -69,7 +69,7 @@ Returns the complete current state as a deterministic snapshot:
 The sorting is deliberate: snapshots are structurally comparable without additional normalization. Diff two snapshots and every difference is meaningful, not an ordering artifact.
 
 **`debug.tick`**  
-The most powerful of the five. Send `{"kind": "debug.tick", "head": {"corrId": "...", "debugTime": T}, "data": {"time": T}}`. The oracle advances virtual time to `T` and synchronously fires every timeout that would have matured by `T`:
+The most powerful of the five. Send `{"kind": "debug.tick", "head": {"corrId": "...", "resonate:debug_time": T}, "data": {"time": T}}`. The server advances virtual time to `T` and synchronously fires every timeout that would have matured by `T` (the oracle does this against its in-memory map; the running reference server runs the same timeout processing against persistent storage):
 - Promise timeouts: settles pending promises (timer → `resolved`, else → `rejectedTimedout`), triggers settlement scrub, enqueues `unblock` messages, runs `enqueueResume` on callbacks.
 - Lease timeouts: returns acquired tasks to `pending`, re-arms retry timeout, emits `execute`.
 - Retry timeouts: re-emits `execute` for pending tasks.
@@ -77,8 +77,8 @@ The most powerful of the five. Send `{"kind": "debug.tick", "head": {"corrId": "
 
 This lets your test advance from `T=0` to `T=50000` in a single call and observe exactly the state the spec says should result, without waiting on real-time.
 
-<Callout type="caution" title="debug.tick requires debugTime in the head">
-The `debug.tick` handler validates that `req.head.debug_time == data.time`. Omitting the `debugTime` header or setting it to a different value returns `400`. Set it consistently, because `debugTime` is also what `oracle.rs`'s `resolve_time()` uses as `now` for every other operation — so your time-controlled test sequence must set it on every request, not just `debug.tick`.
+<Callout type="caution" title="Keep resonate:debug_time consistent">
+If `head."resonate:debug_time"` is present on a `debug.tick`, it must equal `data.time` — a mismatch returns `400`. Omitting it is not an error, but then virtual time is not applied to the operation. Set it consistently, because `resonate:debug_time` is also what `resolve_time()` uses as `now` for every other operation — so a time-controlled test sequence must set it on every request, not just `debug.tick`.
 </Callout>
 
 ## The structural invariants: assert after every operation
@@ -105,7 +105,7 @@ The oracle's `debug.snap` response gives you everything you need to check all se
 
 **Diff tests.** Feed the same operation sequences to the ScyllaDB implementation and to the reference server, compare responses and snapshots. This is oracle-diff with the reference server as oracle — the same technique described above. It exercises the full protocol surface under realistic latency.
 
-**Kill tests.** Inject random process kills during operation sequences and verify that the named invariants all hold after recovery. The documented characterization across the project is 51 named invariants checked on every snapshot.
+**Kill tests.** Inject random process kills during operation sequences and verify that the named invariants all hold after recovery. The invariant set lives in `internal/test/invariants.go` — 53 named invariants at the time of writing, checked on every snapshot (the set grows with the project).
 
 **Linearizability tests.** Run concurrent clients and record the history of operations and responses, then pass the history through [Porcupine](https://github.com/anishathalye/porcupine) — a Go implementation of Wing-Gong linearizability checking. A protocol that is explainable by some sequential execution of the abstract machine will produce a linearizable history. If Porcupine finds no valid sequential explanation, the implementation has a consistency bug.
 

--- a/content/docs/server/testing-and-conformance.mdx
+++ b/content/docs/server/testing-and-conformance.mdx
@@ -1,0 +1,120 @@
+---
+title: "Testing and conformance"
+pageTitle: "Testing and conformance: what you can verify today"
+description: "How to build an oracle-diff harness against the public reference state machine, use the debug endpoints for seeded simulation, assert the spec's structural invariants, and understand the current state of public conformance tooling."
+hideTitle: true
+---
+
+# Testing and conformance: what you can verify today
+
+The conformance question is: does your server behave identically to the normative abstract machine for every valid input sequence? This chapter explains the tools and techniques you can reach for today — all of them anchored on public artifacts — and names what does not yet exist publicly so you know what you are not getting.
+
+See also: [Unspecified surface](/server/unspecified-surface) — before you write conformance tests, know which behaviors are yours to choose.
+
+## The oracle: your primary reference
+
+`resonatehq/resonate` ships [`src/oracle.rs`](https://github.com/resonatehq/resonate/blob/main/src/oracle.rs) (Apache-2.0). It is a pure in-memory implementation of every protocol handler — the same `promise.get`, `task.acquire`, `task.suspend`, settlement scrub, and timeout-projection logic the full SQLite/Postgres/MySQL server runs, extracted into a self-contained struct with no I/O:
+
+```rust
+pub struct Oracle {
+    promises: HashMap<String, Promise>,
+    tasks: HashMap<String, Task>,
+    schedules: HashMap<String, Schedule>,
+    p_timeouts: Vec<PTimeout>,
+    t_timeouts: Vec<TTimeout>,
+    s_timeouts: Vec<STimeout>,
+    outgoing: Vec<(String, Value)>,
+}
+
+impl Oracle {
+    pub fn apply(&mut self, req: &RequestEnvelope) -> ResponseEnvelope { ... }
+}
+```
+
+`apply` dispatches a `RequestEnvelope` to the appropriate handler and returns a `ResponseEnvelope`. Every handler is deterministic: given the same state, the same request, and the same `now`, the output is identical every time. The `now` value comes from `req.head.debug_time` if set — overriding the wall clock — which is how seeded simulation works.
+
+The oracle-diff technique is direct: feed the same sequence of `RequestEnvelope` values to an oracle instance *and* to your server. Compare the `ResponseEnvelope` returned by each operation. Then call `debug.snap` on both after each step and diff the snapshots. Any divergence is a bug — either in your implementation or in a model you've built on top of it. The oracle is the tiebreaker.
+
+This is the same technique the [SDK testing guide](/sdk/testing-against-the-spec) teaches for SDK conformance; the direction is reversed (you are the server, not the SDK), but the oracle is the same artifact.
+
+<Callout type="note" title="The Lean spec is also executable">
+The [`resonatehq/resonate-specification`](https://github.com/resonatehq/resonate-specification) repo is a valid Lean 4 project. `lake build` compiles it. You can call handlers directly from a Lean test or extract the generated `.olean` files for programmatic use — giving you a second, formally-checkable oracle layer independent of the Rust oracle. The Lean spec is normative; `oracle.rs` is an authoritative implementation of it. When they agree, you have high confidence.
+</Callout>
+
+## Reference-server debug endpoints
+
+The reference server exposes five debug endpoints, all handled in `oracle.rs`. They are reference-server tooling — they are not defined by the Lean spec — but they work against any server that implements them, and they are the primitives that make seeded simulation tractable.
+
+**`debug.start` / `debug.stop`**  
+Return `200 {}` and change nothing. Use them to bracket a test scenario: send `debug.start` before the first operation, `debug.stop` after the last assertion. In the oracle they are explicit no-ops (lines 130–135 of `oracle.rs`); in the full server they can toggle debug-mode routing if you wire that up.
+
+**`debug.reset`**  
+Clears all state — promises, tasks, schedules, all timeout queues, the outbox. Returns `200 {}`. Call this between test cases to get a clean slate without restarting the process.
+
+**`debug.snap`**  
+Returns the complete current state as a deterministic snapshot:
+
+```json
+{
+  "promises": [...],       // sorted by id
+  "callbacks": [...],      // sorted by awaited, then awaiter
+  "listeners": [...],      // sorted by promise_id, then address
+  "tasks": [...],          // sorted by id
+  "promiseTimeouts": [...], // sorted by id
+  "taskTimeouts": [...],   // sorted by id
+  "messages": [...]        // outbox entries, in emission order
+}
+```
+
+The sorting is deliberate: snapshots are structurally comparable without additional normalization. Diff two snapshots and every difference is meaningful, not an ordering artifact.
+
+**`debug.tick`**  
+The most powerful of the five. Send `{"kind": "debug.tick", "head": {"corrId": "...", "debugTime": T}, "data": {"time": T}}`. The oracle advances virtual time to `T` and synchronously fires every timeout that would have matured by `T`:
+- Promise timeouts: settles pending promises (timer → `resolved`, else → `rejectedTimedout`), triggers settlement scrub, enqueues `unblock` messages, runs `enqueueResume` on callbacks.
+- Lease timeouts: returns acquired tasks to `pending`, re-arms retry timeout, emits `execute`.
+- Retry timeouts: re-emits `execute` for pending tasks.
+- Schedule timeouts: runs the `catchUp` loop — fires every missed cron occurrence, advances `nextRunAt`.
+
+This lets your test advance from `T=0` to `T=50000` in a single call and observe exactly the state the spec says should result, without waiting on real-time.
+
+<Callout type="caution" title="debug.tick requires debugTime in the head">
+The `debug.tick` handler validates that `req.head.debug_time == data.time`. Omitting the `debugTime` header or setting it to a different value returns `400`. Set it consistently, because `debugTime` is also what `oracle.rs`'s `resolve_time()` uses as `now` for every other operation — so your time-controlled test sequence must set it on every request, not just `debug.tick`.
+</Callout>
+
+## The structural invariants: assert after every operation
+
+The [task model](/spec/system-model/tasks) and [recovery protocol](/spec/execution-model/recovery-protocol#server-invariants) name structural invariants the server must hold after every transition. These are your most valuable assertions because they are total — they say nothing about a specific scenario, only about the state that any valid sequence of operations must produce. A violation pins the bug to the exact step that broke the invariant.
+
+The seven task invariants:
+
+1. **Every task has a corresponding promise** — no orphan tasks.
+2. **Every pending task has a retry timeout** — a claimable-but-unclaimed task will eventually be re-offered.
+3. **Every acquired task has a lease** — a worker that dies is detected and replaced.
+4. **Every suspended task has at least one callback** on a promise it awaits — it can be woken.
+5. **No suspended task has an already-consumed callback** — a settled promise can't leave a task parked forever.
+6. **No suspended task has a timeout** — suspension is open-ended; it waits on a settlement, not a clock.
+7. **No fulfilled task has a timeout** — a terminal task holds no obligations.
+
+The Lean spec is the normative source for these; the [prose spec pages](/spec/system-model/tasks) restate them in readable form. Verify your assertions against the Lean files — several invariant identifiers in the spec source invert the described condition (a `no-timeout`-style name guards "must have a timeout"). Assert the described condition, not the name.
+
+The oracle's `debug.snap` response gives you everything you need to check all seven after every operation in a test loop.
+
+## The ScyllaDB implementation as a worked example
+
+[`resonatehq/resonate-on-scylladb`](https://github.com/resonatehq/resonate-on-scylladb) — source-available under BUSL-1.1 (free for development and evaluation; commercial license for production; converts to Apache 2.0 on 2030-07-01) — demonstrates what a mature conformance-testing posture looks like against a non-reference implementation. Its README describes three test profiles, each runnable as a Docker Compose command:
+
+**Diff tests.** Feed the same operation sequences to the ScyllaDB implementation and to the reference server, compare responses and snapshots. This is oracle-diff with the reference server as oracle — the same technique described above. It exercises the full protocol surface under realistic latency.
+
+**Kill tests.** Inject random process kills during operation sequences and verify that the named invariants all hold after recovery. The documented characterization across the project is 51 named invariants checked on every snapshot.
+
+**Linearizability tests.** Run concurrent clients and record the history of operations and responses, then pass the history through [Porcupine](https://github.com/anishathalye/porcupine) — a Go implementation of Wing-Gong linearizability checking. A protocol that is explainable by some sequential execution of the abstract machine will produce a linearizable history. If Porcupine finds no valid sequential explanation, the implementation has a consistency bug.
+
+This three-layer approach — oracle-diff, fault injection against named invariants, linearizability verification — is the shape worth aiming for.
+
+## What is not public today
+
+The conformance harness — the tooling that replays operation sequences against an arbitrary server and checks invariants after every step — exists and is used internally. It is private by design. No public pass/fail conformance suite exists today. Whether one is published is an open question. Do not wait for it; build your own against the oracle-diff and invariant-assertion techniques above.
+
+---
+
+*Verified against [`resonate-specification@83d64c3`](https://github.com/resonatehq/resonate-specification/tree/83d64c3).*

--- a/content/docs/server/timeouts-and-projection.mdx
+++ b/content/docs/server/timeouts-and-projection.mdx
@@ -37,6 +37,8 @@ def PromiseObject.external (p : PromiseObject) : Bool :=
 
 Promises that carry neither tag — pure callback rendezvous points created by the SDK to coordinate internal workflows — are never added to the promise timeout list. Their only settlement path is an explicit `promise.settle` call from a worker.
 
+One exception to the external-only rule: `task.create` ([`T-02-task.create.lean`](https://github.com/resonatehq/resonate-specification/blob/main/spec/02-actions/T-02-task.create.lean), fresh-promise branch) calls `setPromiseTimeout` **unconditionally**, with no externality check — every task-backed promise created through T-02 gets a timeout entry. The tag-gated arming described above is `promise.create`'s (P-02) behavior.
+
 **`taskTimeouts`** carries two logically distinct entries, distinguished by `kind`:
 - `kind = 0`: pending-retry timeout. Set when a task is first created or returned to `pending`. Fires `onTaskRetryTimeout`, which re-issues the execute message.
 - `kind = 1`: lease-expiration timeout. Set when a task is acquired. Fires `onTaskLeaseTimeout`, which reverts the task to pending and re-issues the execute message.

--- a/content/docs/server/timeouts-and-projection.mdx
+++ b/content/docs/server/timeouts-and-projection.mdx
@@ -1,0 +1,155 @@
+---
+title: "Timeouts and projection"
+pageTitle: "Timeouts and projection"
+description: "The three timeout lists, the four internal transitions, and the projection convention — why your reads and stored state can legally diverge."
+hideTitle: true
+---
+
+# Timeouts and projection
+
+The server maintains three timeout lists and four internal transitions that fire against them. None of these are user-visible API calls; they are background machinery the server runs on its own clock. They are also where the most important correctness property in the machine lives: the **projection convention**, which means that what a handler returns about a promise and what is actually written in storage can legally diverge — and your implementation must handle both sides correctly.
+
+## The three timeout lists
+
+`ServerState` carries three separate timeout lists ([state.lean](https://github.com/resonatehq/resonate-specification/blob/main/spec/01-objects/state.lean), lines 62–76):
+
+```lean
+structure PromiseTimeout where
+  id      : String
+  timeout : Nat
+
+structure TaskTimeout where
+  id      : String
+  kind    : Nat   -- 0 = pending retry, 1 = lease expiration
+  timeout : Nat
+
+structure ScheduleTimeout where
+  id      : String
+  timeout : Nat
+```
+
+**`promiseTimeouts`** is armed when a promise is created — but **only if the promise is external**. A promise is external when it carries a `resonate:target` tag (meaning a task backs it) or a `resonate:timer = "true"` tag ([state.lean](https://github.com/resonatehq/resonate-specification/blob/main/spec/01-objects/state.lean), lines 34–35):
+
+```lean
+def PromiseObject.external (p : PromiseObject) : Bool :=
+  p.tags.has "resonate:target" || p.isTimer
+```
+
+Promises that carry neither tag — pure callback rendezvous points created by the SDK to coordinate internal workflows — are never added to the promise timeout list. Their only settlement path is an explicit `promise.settle` call from a worker.
+
+**`taskTimeouts`** carries two logically distinct entries, distinguished by `kind`:
+- `kind = 0`: pending-retry timeout. Set when a task is first created or returned to `pending`. Fires `onTaskRetryTimeout`, which re-issues the execute message.
+- `kind = 1`: lease-expiration timeout. Set when a task is acquired. Fires `onTaskLeaseTimeout`, which reverts the task to pending and re-issues the execute message.
+
+**`scheduleTimeouts`** holds one entry per schedule, set to `nextRunAt`. Fires `onScheduleTimeout`.
+
+## The four internal transitions
+
+### onPromiseTimeout
+
+[02-timeouts.lean](https://github.com/resonatehq/resonate-specification/blob/main/spec/02-actions/02-timeouts.lean), lines 8–41.
+
+Fires when a promise timeout entry matures. Guard: if the promise does not exist, or is not `pending`, this is a no-op. Otherwise:
+
+1. Settle the promise — `resolved` if `p.isTimer`, `rejectedTimedout` otherwise. `settledAt` is set to `p.timeoutAt` (the original deadline), not `now`.
+2. Delete the promise timeout entry.
+3. If a task exists for this promise id: transition it to `fulfilled`, clear `pid`/`ttl`/`resumes`, and delete its task timeout entries.
+4. **Settlement scrub**: scan every pending promise in the store and remove this promise's id from their `callbacks` list. A timed-out promise can never resume an awaiter; callbacks pointing to it would stall forever without this step.
+5. Send an `unblock` message (carrying the settled promise record) to every registered listener address via the outbox.
+6. Call `enqueueResume` for every registered callback (awaiter promise id) — transitioning suspended awaiters back to `pending` and re-issuing their execute messages.
+
+Step 4 is the **settlement scrub**; steps 5–6 are the settlement propagation (listeners, then callbacks). The same three-step block runs identically in `promiseSettle` and `taskFulfill`. `onPromiseTimeout` is the only writer that executes it for expired promises.
+
+### onTaskRetryTimeout
+
+[02-timeouts.lean](https://github.com/resonatehq/resonate-specification/blob/main/spec/02-actions/02-timeouts.lean), lines 43–57.
+
+Fires when a `pending` task's retry timeout (kind 0) matures. Guard: task must exist and be in `pending`. Otherwise no-op.
+
+1. Delete the existing kind-0 timeout entry.
+2. Set a new kind-0 timeout at `now + retryTimeout` (default 5000 ms from `ServerConfig.retryTimeout`).
+3. Re-send an `execute` message to the task's target address (taken from `resonate:target` on the promise).
+
+This is the mechanism that re-offers unclaimed work. A pending task with no worker will be re-dispatched every `retryTimeout` milliseconds until it is acquired or its promise settles.
+
+### onTaskLeaseTimeout
+
+[02-timeouts.lean](https://github.com/resonatehq/resonate-specification/blob/main/spec/02-actions/02-timeouts.lean), lines 59–75.
+
+Fires when an acquired task's lease expires (kind-1 timeout). Guard: task must exist and be in `acquired`. Otherwise no-op.
+
+1. Revert the task to `pending` — clear `pid` and `ttl`.
+2. Delete the existing kind-1 timeout entry.
+3. Set a new kind-0 (pending-retry) timeout at `now + retryTimeout`.
+4. Re-send an `execute` message to the target address.
+
+**The version is not incremented here.** It advances on the next `task.acquire`. A worker that held the lease at version `n` and lost it will find its next mutating operation rejected with `409` once another worker acquires at version `n+1`. See [Implementing tasks](/server/implementing-tasks).
+
+### onScheduleTimeout
+
+[02-timeouts.lean](https://github.com/resonatehq/resonate-specification/blob/main/spec/02-actions/02-timeouts.lean), lines 88–97.
+
+Fires when a schedule's fire time arrives. Runs the `catchUp` loop (which fires `promiseCreate` for every missed occurrence), writes the updated schedule, disarms the current timeout entry, and arms a new one at `nextRunAt`. See [Implementing schedules](/server/implementing-schedules) for the full catch-up semantics.
+
+## The projection convention
+
+This is the hardest property to reason about correctly, and the one most likely to bite you if you skip it.
+
+Several handlers return a promise's state computed from the stored record and the current clock — **without writing the computed state to storage**. This is the projection convention. It appears in `promise.get`, `promise.create` (when the promise already exists), and `promise.settle`. All three follow the same pattern:
+
+> If a stored promise has `state = pending` and `timeoutAt ≤ now`, the handler returns a projected settled record — `resolved` for timer promises (`resonate:timer = "true"`), `rejectedTimedout` for all others, with `settledAt = p.timeoutAt` — **without writing that record to storage**.
+
+The actual write to storage happens only when `onPromiseTimeout` fires.
+
+```text
+Promise created:  { state: pending, timeoutAt: T }
+                          |
+         ... time passes, no timeout handler fired yet ...
+                          |
+              now = T+1   |
+                          ▼
+  promise.get returns:  { state: rejectedTimedout, settledAt: T }
+  storage still holds:  { state: pending, timeoutAt: T }
+                          |
+              now = T+N   |
+                          ▼
+  onPromiseTimeout fires: writes { state: rejectedTimedout, settledAt: T }
+                          sends unblock to listeners
+                          enqueues resumes for callbacks
+```
+
+### Where settlement is actually written
+
+Settlement is written to storage in exactly three places, all of which run the same settlement scrub afterward:
+
+1. **`promiseSettle`** ([P-03](https://github.com/resonatehq/resonate-specification/blob/main/spec/02-actions/P-03-promise.settle.lean)) — direct settle by an API caller, when `p.timeoutAt > now`. If the promise is already expired (`p.timeoutAt ≤ now`), `promiseSettle` returns `200` with the projected state and does **not** write.
+2. **`taskFulfill`** ([T-07](https://github.com/resonatehq/resonate-specification/blob/main/spec/02-actions/T-07-task.fulfill.lean)) — task completes and settles its promise atomically, when `p.state == pending && p.timeoutAt > now`. If the promise is expired, `taskFulfill` returns `409` — the task cannot fulfill against an already-projected promise.
+3. **`onPromiseTimeout`** — the background transition that is the only writer for expired promises. This is what actually delivers the settlement scrub, listener notifications, and callback resumes for timed-out promises.
+
+### Implementation consequences
+
+**Your storage layer must not assume read-your-writes symmetry on promise state.** A query for "all settled promises with `settledAt < T`" will miss promises that have logically expired but haven't been processed by `onPromiseTimeout` yet. A query for "all pending promises" may include promises that would project as settled to any handler that reads them. Both queries are internally consistent — they reflect different moments in the machine — but you must be explicit about which you're asking and why.
+
+**The timeout machinery is a correctness component, not a janitor.** If `onPromiseTimeout` never fires:
+- `promise.get` returns correct results — projection handles it.
+- Listeners never receive their `unblock` message.
+- Awaiting tasks never receive their resume.
+- Work silently stalls — no error, no crash, nothing happening.
+
+An implementation that skips or indefinitely delays promise timeout processing passes every read-path test and fails every durability test. Build the timeout dispatch loop with the same care as the write handlers, and test it explicitly: create a promise with a short `timeoutAt`, let it expire, verify that the listener receives `unblock` and the awaiting task transitions to `pending`.
+
+<Callout type="caution" title="This will bite you if your storage index drives reads">
+If your storage layer builds an index over the `state` field for efficient lookups and you answer `promise.get` from that index, expired promises will return `pending` when they should return `rejectedTimedout`. Projection must happen in handler logic — after the read, before the response — not in the index. Any pending promise whose `timeoutAt ≤ now` must be projected at the point of response construction, even if the storage record still says `pending`.
+</Callout>
+
+## Cross-references
+
+- [Implementing promises](/server/implementing-promises) — `promiseSettle`, `promise.create`, and where promise timeouts are armed
+- [Implementing tasks](/server/implementing-tasks) — `taskFulfill`, version increment on re-acquire, lease and retry timeout lifecycle
+- [Implementing schedules](/server/implementing-schedules) — `onScheduleTimeout` and the catch-up loop
+- [Outbox and delivery](/server/outbox-and-delivery) — `unblock` and `execute` messages emitted by timeout transitions
+- [State model](/server/state-model) — `PromiseTimeout`, `TaskTimeout`, `ScheduleTimeout` struct definitions
+
+---
+
+*Verified against [resonate-specification`@83d64c3`](https://github.com/resonatehq/resonate-specification/tree/83d64c3).*

--- a/content/docs/server/unspecified-surface.mdx
+++ b/content/docs/server/unspecified-surface.mdx
@@ -1,0 +1,115 @@
+---
+title: "Unspecified surface"
+pageTitle: "Unspecified surface: what the spec deliberately leaves open"
+description: "A reference list of behaviors the Lean spec explicitly does not define — search handlers, nextCron, expand, preload, auth, transport, and concurrency — so implementers know what is theirs to choose."
+hideTitle: true
+---
+
+# Unspecified surface: what the spec deliberately leaves open
+
+The Lean spec says exactly what it says and nothing more. This chapter lists every area the spec deliberately leaves open — with what the spec says (or explicitly doesn't), what the reference server does (labeled as such, verified in source), and what you are free to choose. Check your design against this list before you present any implementation decision as "spec-required."
+
+See also: [Testing and conformance](/server/testing-and-conformance) — how to build conformance tests that stay on the specified side of this boundary.
+
+## The three search handlers: P-06, T-11, S-04
+
+**What the spec says.** The Lean files are unambiguous:
+
+```lean
+-- P-06-promise.search.lean
+def promiseSearch (_req : PromiseSearchReq) (_now : Nat) : M PromiseSearchRes := do
+  return { status := 501 }
+
+-- T-11-task.search.lean
+def taskSearch (_req : TaskSearchReq) (_now : Nat) : M TaskSearchRes := do
+  return { status := 501 }
+
+-- S-04-schedule.search.lean
+def scheduleSearch (_req : ScheduleSearchReq) (_now : Nat) : M ScheduleSearchRes := do
+  return { status := 501 }
+```
+
+The Lean handlers for P-06, T-11, and S-04 ignore their request arguments entirely and return `501`. Filter semantics, pagination, sort order, cursor format — none of this is specified. Sources: [`spec/02-actions/P-06-promise.search.lean`](https://github.com/resonatehq/resonate-specification/blob/main/spec/02-actions/P-06-promise.search.lean), [`T-11-task.search.lean`](https://github.com/resonatehq/resonate-specification/blob/main/spec/02-actions/T-11-task.search.lean), [`S-04-schedule.search.lean`](https://github.com/resonatehq/resonate-specification/blob/main/spec/02-actions/S-04-schedule.search.lean).
+
+**What the reference server does.** The reference server implements all three with cursor-based pagination, optional state filter, and tag containment filter (all provided tags must be present on the returned object). Default page size is 100 for promises and tasks, 10 for schedules; maximum is 1000. Results are sorted by `id` ascending; the cursor is the `id` of the last returned item. This is reference-server convention, not spec behavior.
+
+**What you are free to choose.** Any filter semantics, any pagination scheme, any sort order, any cursor format. You may return `501` and be fully conformant. If you implement search, document what your implementation provides — no client should assume they will get reference-server semantics from a non-reference server.
+
+## `nextCron` and `expand`: declared opaque
+
+**What the spec says.** [`spec/01-objects/state.lean`](https://github.com/resonatehq/resonate-specification/blob/main/spec/01-objects/state.lean) declares both functions with no body:
+
+```lean
+opaque nextCron : (cron : String) → (after : Nat) → Nat
+opaque expand : (template id : String) → (timestamp : Nat) → String
+```
+
+`nextCron` computes the next cron fire time after a given epoch-millisecond timestamp. `expand` turns a promise-id template and a schedule id into a concrete promise id at a given timestamp. The `opaque` keyword in Lean means: the function exists and has this type, but its definition is hidden — the spec makes no claims about the output for any input. Every handler that uses them (`schedule.create` for `nextCron`, the `catchUp` loop for both) is parameterized by whatever your implementation provides.
+
+**What the reference server does.** `oracle.rs` calls `util::compute_next_cron()` for cron advancement and uses a simple template-substitution expansion: `promise_id_template.replace("{{.id}}", &schedule_id).replace("{{.timestamp}}", &current_timeout.to_string())`. The cron parser is a standard Go/Rust library call; the expansion is literal string substitution with two named placeholders.
+
+**What you are free to choose.** Any standards-compliant cron parser and any cron dialect. Any template expansion format — your promise-id templates can use different placeholder syntax. The only constraint is internal consistency: whatever `expand` produces must be a valid promise id, and `nextCron` must return a timestamp strictly after its `after` argument (otherwise the `catchUp` loop does not terminate).
+
+<Callout type="caution" title="nextCron returning ≤ after will loop forever">
+The `catchUp` transition in `02-timeouts.lean` advances `nextRunAt` by calling `nextCron s.cron cronTime` in a loop until it surpasses `now`. If your `nextCron` implementation ever returns a value ≤ `after`, this loop does not terminate. Validate that your cron library always steps forward.
+</Callout>
+
+## `preload`: present in wire types, semantics unspecified
+
+**What the spec says.** Four response types carry a `preload` field in [`spec/01-objects/types.lean`](https://github.com/resonatehq/resonate-specification/blob/main/spec/01-objects/types.lean):
+
+```lean
+structure TaskCreateRes where
+  ...
+  preload : List PromiseRecord := []   -- line 180
+
+structure TaskAcquireRes where
+  ...
+  preload : List PromiseRecord := []   -- line 194
+
+structure TaskFenceRes where
+  ...
+  preload : List PromiseRecord := []   -- line 216
+
+structure TaskSuspendRes where
+  ...
+  preload : List PromiseRecord := []   -- line 241
+```
+
+Every handler in the spec that returns one of these types leaves `preload` at the empty-list default. No Lean handler assigns a non-empty list to it. The field exists in the type; its semantics do not.
+
+**What the reference server does.** The reference server populates `preload` in its `preload()` helper (`oracle.rs` lines 2109–2129): it reads the `resonate:branch` tag from the acquired promise's tags and returns all other promises that share the same branch value. The intent is to give the worker a warm cache of sibling promises it will probably need, saving round trips. This optimization is entirely reference-server behavior — not a protocol requirement.
+
+**What you are free to choose.** Return an empty list and you are fully conformant. Populate it with any set of promise records that would be useful to the receiving worker. No client should assume that `preload` is always empty, always populated, or populated by any particular selection criterion. If your implementation populates it, document what you include and why.
+
+## Authentication and authorization
+
+**What the spec says.** Nothing. The abstract machine has no auth model. Every handler takes a request and a current time; there is no principal, no token, no permission check anywhere in the Lean spec. The machine is not multi-tenant and does not distinguish callers.
+
+**What the reference server does.** The reference server provides optional API-key authentication on HTTP requests. It is not part of the protocol and is not modeled.
+
+**What you are free to choose.** Any authentication and authorization scheme, or none. JWT, mTLS, API keys, IP allowlists, internal-network-only deployment — all are valid. None is required.
+
+## Transport encoding
+
+**What the spec says.** The abstract machine models handlers as pure functions `Req → now → M Res`. It does not model HTTP. It does not define JSON. The envelope shape — the `kind`/`head`/`data` structure, the `corrId` field, the `version` string, the HTTP method and path — is not in any Lean file.
+
+**What the reference server does.** The reference server uses an HTTP/JSON transport with a specific envelope format. All existing Resonate SDKs speak this envelope. See [Envelope and transport](/server/envelope-and-transport) for the full definition.
+
+**What you are free to choose.** More than the Lean model constrains, less than the full protocol allows: the [prose spec's message-passing protocol](/spec/execution-model/message-passing#address-schemes) names HTTP as the required transport for a conformant implementation, with other schemes (NATS, Kafka, poll/SSE, gRPC, Unix sockets) optional additions. Within that, serialization details and any extra transports are yours. `resonate-on-nats` demonstrates the trade: it speaks NATS pub/sub instead of HTTP, which is exactly why existing SDKs cannot talk to it without a matching transport layer — plan for that if you deviate.
+
+## Concurrency and isolation
+
+**What the spec says.** The abstract machine is a sequential state machine. Its computation type is `StateM ServerState` — a single-threaded state thread. There is no concurrency primitive, no lock, no transaction isolation level anywhere in the Lean model.
+
+**What this means for your implementation.** Your server must behave *as if* it were executing operations one at a time in some sequential order. Concurrent requests are fine as long as the observable results — responses, state snapshots — are explainable by *some* valid sequential execution of the abstract machine. This is the standard linearizability criterion. See [Abstract machine](/server/abstract-machine) for the state model your concurrent implementation must serialize against.
+
+**What you are free to choose.** Any concurrency model: single-threaded event loop, thread-per-request with mutex, MVCC, Paxos-based LWT (as `resonate-on-scylladb` uses), JetStream KV CAS (as `resonate-on-nats` uses). The test that matters is whether concurrent executions produce a linearizable history against the abstract machine — not whether you used a specific locking primitive to achieve it.
+
+<Callout type="note" title="The version field is your friend here">
+Every task mutation is version-fenced. If two workers race to acquire the same task, one wins the version increment and the other gets `409 Conflict`. You do not need to serialize the entire server to prevent double-acquisition; you need an atomic compare-and-swap on the task's version field. That is the minimal isolation unit the protocol requires.
+</Callout>
+
+---
+
+*Verified against [`resonate-specification@83d64c3`](https://github.com/resonatehq/resonate-specification/tree/83d64c3).*


### PR DESCRIPTION
**Migration plan PR 4** — the `/server` track goes from stub to a complete guide for implementing a conformant Distributed Async Await server.

> **Stacked on #27** (spec migration) because chapters cross-link `/spec/*` pages. Merge #27 first; this PR then retargets to `main` automatically.

## What's in it

12 chapters, written against the Lean spec pinned at `resonate-specification@83d64c3` (every chapter footer carries the pin):

| Section | Chapters |
|---|---|
| — | **Overview**: durable execution is a protocol; what "conformant" means; the three implementations (SQL / wide-column / broker) as proof, with honest maturity + license labels |
| The machine | **abstract-machine** (ServerState, handlers as pure `Req → now → M Res` functions, the sequential-machine mental model) · **state-model** (every record/enum, wire-visible vs internal fields, version as fencing token, lease = ttl+pid) |
| The wire | **envelope-and-transport** (the reference server's JSON envelope, labeled as reference convention; the prose spec's HTTP-required rule vs the Lean model's transport silence; full status-code vocabulary incl. the 300 and 501 sharp edges) |
| The handlers | **implementing-promises** (P-01..P-06, incl. create's 200-only idempotency and the settlement scrub) · **implementing-tasks** (T-01..T-11, incl. the version-increments-only-on-acquire rule stated emphatically) · **implementing-schedules** (S-01..S-04 + the catchUp loop, with nextCron/expand flagged opaque) |
| Internal transitions | **timeouts-and-projection** (three timeout lists, four transitions, and the projection convention — reads legally diverge from stored state) · **outbox-and-delivery** (exactly two message types, upsert keying, the full enqueue-site enumeration, the resume chain) |
| Production wedge | **storage-strategies** (substrate requirements + three worked case studies: reference server SQL, ScyllaDB LWT, NATS JetStream KV — drop-in asymmetry stated first) · **testing-and-conformance** (oracle-diff vs public `oracle.rs`, `debug.*` seeded simulation, spec invariants; no public conformance suite — framed as an open question per D7) |
| Boundaries | **unspecified-surface** (the reference list of what the spec deliberately does not define) |

## Editorial decisions applied

- **D6 license wording** verbatim wherever the Go servers are license-labeled; never "open source"; reference server separately "Apache-2.0".
- **D7 conformance framing**: what you can verify today, publicly; the harness is private by design; nothing promised.
- No links to any private repo.
- ScyllaDB and NATS repo claims verified against their public READMEs/source at write time. ⚠️ If the ScyllaDB embargo (NATS-first partnership sequencing) extends to this documentation surface, say the word and I'll pull the ScyllaDB case study into a follow-up — it's isolated to clearly-bounded sections of the overview, storage, and testing chapters.

## Verification

- Every semantic claim (status codes, validation order, version/lease/timeout rules, outbox keying, projection) was verified against the actual `.lean` files by the chapter writers.
- Two independent adversarial review passes followed: a spec-accuracy pass (5 confirmed defects — all fixed, including two that would have silently broken an implementer's settlement path: the missing `task.fulfill` unblock site and the missing `setPromiseTimeout` in `task.create`) and a cross-chapter consistency/compliance pass (terminology, anchors, license wording, handler counts — all fixed).
- `npm run build` green; `check-links` **0 internal broken**.