### PR TITLE
Tighten copy on server handbook pages

### DIFF
--- a/content/docs/server/abstract-machine.mdx
+++ b/content/docs/server/abstract-machine.mdx
@@ -25,7 +25,7 @@ structure ServerState where
   outbox           : List OutboxEntry
 ```
 
-That's it. Every object the server knows about lives in one of those eight fields. There is no connection pool, no clock, no filesystem reference. `ServerState` is a plain inductive value; two states are equal iff their fields are equal. This makes the spec executable as a pure function and mechanically comparable against any implementation you build.
+Those eight fields are the entire server state — every object the server knows about lives in one of them. There is no connection pool, no clock, no filesystem reference. `ServerState` is a plain inductive value; two states are equal iff their fields are equal. This makes the spec executable as a pure function and mechanically comparable against any implementation you build.
 
 `ServerConfig` carries one field today: `retryTimeout : Nat := 5000` (milliseconds). Everything else — auth, transport, indexes — is outside the machine.
 

--- a/content/docs/server/unspecified-surface.mdx
+++ b/content/docs/server/unspecified-surface.mdx
@@ -7,7 +7,7 @@ hideTitle: true
 
 # Unspecified surface: what the spec deliberately leaves open
 
-The Lean spec says exactly what it says and nothing more. This chapter lists every area the spec deliberately leaves open — with what the spec says (or explicitly doesn't), what the reference server does (labeled as such, verified in source), and what you are free to choose. Check your design against this list before you present any implementation decision as "spec-required."
+The Lean spec defines a precise, bounded surface; everything outside it is deliberately left open. This chapter lists every such area — with what the spec says (or explicitly doesn't), what the reference server does (labeled as such, verified in source), and what you are free to choose. Check your design against this list before you present any implementation decision as "spec-required."
 
 See also: [Testing and conformance](/server/testing-and-conformance) — how to build conformance tests that stay on the specified side of this boundary.
 


### PR DESCRIPTION
Small copy pass over two server-handbook pages — replaces fragment-tag phrasing with full sentences, no content changes:

- **server/abstract-machine** — "That's it. Every object the server knows about lives in one of those eight fields." → "Those eight fields are the entire server state — every object the server knows about lives in one of them." (The connection-pool/clock/filesystem enumeration is unchanged — that's load-bearing spec content.)
- **server/unspecified-surface** — "The Lean spec says exactly what it says and nothing more." → "The Lean spec defines a precise, bounded surface; everything outside it is deliberately left open."

`llms-full.txt` is gitignored here and regenerates at build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)